### PR TITLE
fixed import: added lost property into COATools2Preferences

### DIFF
--- a/coa_tools2/__init__.py
+++ b/coa_tools2/__init__.py
@@ -115,6 +115,11 @@ class COATools2Preferences(bpy.types.AddonPreferences):
         min=0,
         max=59,
     )
+    sprite_import_export_scale: bpy.props.FloatProperty(
+        name="Scale",
+        description="Import/Export scale factor, 1 px = X units",
+        default=0.01,
+    )
 
     def draw(self, context):
         layout = self.layout


### PR DESCRIPTION
The importer needed sprite_import_export_scale value in user preferences. 0.01 seems to be the value from original repo:
`(from /Blender/coa_tools/__init__.py:89)`
`sprite_import_export_scale: bpy.props.FloatProperty(name="Sprite import/export scale",default=0.01)`