### PR TITLE
add tex_node extension = clip

### DIFF
--- a/coa_tools2/operators/import_sprites.py
+++ b/coa_tools2/operators/import_sprites.py
@@ -402,6 +402,7 @@ class COATOOLS2_OT_ImportSprite(bpy.types.Operator):
                 output_node = node
         # create all required nodes and connect them
         tex_node = node_tree.nodes.new("ShaderNodeTexImage")
+        tex_node.extension = "CLIP"
         tex_node.interpolation = "Closest"
         tex_node.image = bpy.data.images[name]
 


### PR DESCRIPTION
In #16, meshes could be edited beyond the borders of the image, but I found that the textures repeats if we edit beyond the borders.
This PR is a fix for this problem.