### PR TITLE
fix(ci): make jsx syntax check compatible with ExtendScript

### DIFF
--- a/.github/workflows/create-release-from-tags.yml
+++ b/.github/workflows/create-release-from-tags.yml
@@ -81,7 +81,9 @@ jobs:
               python -m py_compile "$file"
               ;;
             jsx)
-              node --check "$file"
+              # ExtendScript directives (for example "#target Photoshop") are not
+              # valid JavaScript syntax for Node, so strip preprocessor lines first.
+              sed '/^[[:space:]]*#/d' "$file" | node --check
               ;;
             *)
               echo "Unknown extension: $file"


### PR DESCRIPTION
## Summary\n- fix tag-release workflow syntax check for Photoshop/BlenderExporter.jsx\n- strip ExtendScript preprocessor directives (e.g. #target) before running 
ode --check\n- keep Python syntax checks unchanged\n\n## Why\n
ode --check fails on .jsx files with ExtendScript directives due ERR_UNKNOWN_FILE_EXTENSION / parser mismatch.