### PR TITLE
chore: sync master into develop (jsx workflow fix)

### DIFF
--- a/.github/workflows/create-release-from-tags.yml
+++ b/.github/workflows/create-release-from-tags.yml
@@ -81,7 +81,9 @@ jobs:
               python -m py_compile "$file"
               ;;
             jsx)
-              node --check "$file"
+              # ExtendScript directives (for example "#target Photoshop") are not
+              # valid JavaScript syntax for Node, so strip preprocessor lines first.
+              sed '/^[[:space:]]*#/d' "$file" | node --check
               ;;
             *)
               echo "Unknown extension: $file"


### PR DESCRIPTION
## Summary\n- sync latest master into develop\n- includes tag-release workflow fix for ExtendScript .jsx syntax check