### PR TITLE
fix: stabilize dependency installer reporting

### DIFF
--- a/coa_tools2/__init__.py
+++ b/coa_tools2/__init__.py
@@ -155,6 +155,7 @@ class COATools2Preferences(bpy.types.AddonPreferences):
             icon="CHECKMARK" if deps_state["cv2"] else "ERROR",
         )
         row = box.row(align=True)
+        row.operator_context = "INVOKE_DEFAULT"
         row.operator(
             "coa_tools2.install_python_dependencies",
             icon="IMPORT",

--- a/coa_tools2/operators/automesh.py
+++ b/coa_tools2/operators/automesh.py
@@ -36,6 +36,15 @@ except Exception:
 # ======================================================================================================================
 
 
+def has_interactive_ui(context):
+    return (
+        not bpy.app.background
+        and getattr(context, "window", None) is not None
+        and getattr(context, "screen", None) is not None
+        and getattr(context, "window_manager", None) is not None
+    )
+
+
 def get_texture_image(context, obj) -> Optional[bpy.types.Image]:
     """Get the texture image from the object material"""
     if obj.type == "MESH":
@@ -50,7 +59,7 @@ def get_texture_image(context, obj) -> Optional[bpy.types.Image]:
 
 def show_dependency_install_help(context):
     wm = getattr(context, "window_manager", None)
-    if wm is None:
+    if wm is None or not has_interactive_ui(context):
         return
 
     def draw(menu, _context):
@@ -58,6 +67,7 @@ def show_dependency_install_help(context):
         layout.label(text="Automesh needs numpy and opencv (cv2).", icon="ERROR")
         layout.label(text="Open Preferences > Add-ons > COA Tools2.")
         layout.label(text="Click 'Install numpy / opencv'.")
+        layout.operator_context = "INVOKE_DEFAULT"
         layout.operator(
             "coa_tools2.install_python_dependencies",
             icon="IMPORT",
@@ -332,11 +342,16 @@ class COATOOLS2_OT_AutomeshFromTexture(bpy.types.Operator):
                 print("COA Tools2 automesh dependency import errors:")
                 for module_name, error in dep_errors.items():
                     print(f"- {module_name}: {error}")
-            self.report(
-                {"ERROR"},
-                "Automesh needs compatible numpy/opencv. Open Preferences > Add-ons > COA Tools2 and click 'Install numpy / opencv'.",
+            message = (
+                "Automesh needs compatible numpy/opencv. Open Preferences > Add-ons > "
+                "COA Tools2 and click 'Install numpy / opencv'."
             )
-            show_dependency_install_help(context)
+            if has_interactive_ui(context):
+                self.report({"ERROR"}, message)
+                show_dependency_install_help(context)
+            else:
+                print(f"COA Tools2: {message}")
+                self.report({"WARNING"}, message)
             return {"CANCELLED"}
 
         wm = context.window_manager

--- a/coa_tools2/operators/install_dependencies.py
+++ b/coa_tools2/operators/install_dependencies.py
@@ -4,6 +4,62 @@ import threading
 from .. import dependency_manager
 
 
+def _has_modal_ui(context):
+    return (
+        not bpy.app.background
+        and getattr(context, "window", None) is not None
+        and getattr(context, "screen", None) is not None
+        and getattr(context, "window_manager", None) is not None
+    )
+
+
+def _new_install_state():
+    return {
+        "done": False,
+        "success": False,
+        "logs": [],
+        "progress": 0.0,
+        "status_message": "Starting dependency installation...",
+    }
+
+
+def _make_progress_callback(state):
+    def progress_callback(progress, message):
+        state["progress"] = max(0.0, min(100.0, float(progress)))
+        state["status_message"] = str(message)
+
+    return progress_callback
+
+
+def _print_failed_install_log(logs):
+    failed_log = None
+    for log in logs:
+        if log["returncode"] != 0:
+            failed_log = log
+            break
+
+    if failed_log is None:
+        return
+
+    print("COA Tools2 dependency install failed:")
+    print("Command:", " ".join(failed_log["command"]))
+    if failed_log["stdout"]:
+        print(failed_log["stdout"])
+    if failed_log["stderr"]:
+        print(failed_log["stderr"])
+
+
+def _exception_log(exc):
+    return [
+        {
+            "command": ["dependency-install"],
+            "returncode": 1,
+            "stdout": "",
+            "stderr": f"{type(exc).__name__}: {exc}",
+        }
+    ]
+
+
 class COATOOLS2_OT_InstallPythonDependencies(bpy.types.Operator):
     bl_idname = "coa_tools2.install_python_dependencies"
     bl_label = "Install numpy / opencv"
@@ -16,127 +72,108 @@ class COATOOLS2_OT_InstallPythonDependencies(bpy.types.Operator):
     def poll(cls, context):
         return not cls._is_running
 
-    def _progress_callback(self, progress, message):
-        self.progress = max(0.0, min(100.0, float(progress)))
-        self.status_message = str(message)
-
-    def _install_worker(self):
-        success, logs = dependency_manager.install_dependencies(
-            progress_callback=self._progress_callback
-        )
-        self.success = success
-        self.logs = logs
-        self.done = True
-
-    def _start(self, context):
-        if COATOOLS2_OT_InstallPythonDependencies._is_running:
-            self.report({"WARNING"}, "Dependency installation is already running.")
-            return {"CANCELLED"}
-
-        if context.window is None or context.screen is None:
+    def _install_worker(self, state):
+        try:
             success, logs = dependency_manager.install_dependencies(
-                progress_callback=self._progress_callback
+                progress_callback=_make_progress_callback(state)
             )
-            if success:
-                self.report(
-                    {"INFO"},
-                    "Installed numpy/opencv. Re-enable addon or restart Blender.",
-                )
-                return {"FINISHED"}
+        except Exception as exc:
+            success = False
+            logs = _exception_log(exc)
+            state["status_message"] = "Installation failed."
 
-            failed_log = None
-            for log in logs:
-                if log["returncode"] != 0:
-                    failed_log = log
-                    break
-            if failed_log is not None:
-                print("COA Tools2 dependency install failed:")
-                print("Command:", " ".join(failed_log["command"]))
-                if failed_log["stdout"]:
-                    print(failed_log["stdout"])
-                if failed_log["stderr"]:
-                    print(failed_log["stderr"])
-            self.report(
-                {"ERROR"},
-                "Dependency installation failed. Existing numpy/cv2 may be incompatible. See system console.",
-            )
-            return {"CANCELLED"}
+        state["success"] = success
+        state["logs"] = logs
+        state["done"] = True
 
-        COATOOLS2_OT_InstallPythonDependencies._is_running = True
-        self.done = False
-        self.success = False
-        self.logs = []
-        self.progress = 0.0
-        self.status_message = "Starting dependency installation..."
-
-        wm = context.window_manager
-        wm.progress_begin(0, 100)
-        self._timer = wm.event_timer_add(0.2, window=context.window)
-        wm.modal_handler_add(self)
-
-        self._thread = threading.Thread(target=self._install_worker, daemon=True)
-        self._thread.start()
-
-        return {"RUNNING_MODAL"}
-
-    def invoke(self, context, event):
-        start_result = self._start(context)
-        if "CANCELLED" in start_result:
-            return start_result
-        return context.window_manager.invoke_popup(self, width=460)
-
-    def execute(self, context):
-        return self._start(context)
-
-    def draw(self, context):
-        layout = self.layout
-        layout.label(text="Installing numpy/opencv in Blender Python...")
-        layout.label(text=f"Progress: {int(self.progress)}%")
-        layout.label(text=self.status_message)
-        if not self.done:
-            layout.label(text="This window closes automatically when done.", icon="INFO")
-
-    def modal(self, context, event):
-        if event.type != "TIMER":
-            return {"PASS_THROUGH"}
-
-        wm = context.window_manager
-        wm.progress_update(int(self.progress))
-
-        # refresh UI while popup is visible
-        for area in context.screen.areas:
-            area.tag_redraw()
-
-        if not self.done:
-            return {"PASS_THROUGH"}
-
-        wm.progress_end()
-        wm.event_timer_remove(self._timer)
-        COATOOLS2_OT_InstallPythonDependencies._is_running = False
-
-        if self.success:
+    def _finish_install(self, success, logs):
+        if success:
             self.report(
                 {"INFO"},
                 "Installed numpy/opencv. Re-enable addon or restart Blender.",
             )
             return {"FINISHED"}
 
-        failed_log = None
-        for log in self.logs:
-            if log["returncode"] != 0:
-                failed_log = log
-                break
-
-        if failed_log is not None:
-            print("COA Tools2 dependency install failed:")
-            print("Command:", " ".join(failed_log["command"]))
-            if failed_log["stdout"]:
-                print(failed_log["stdout"])
-            if failed_log["stderr"]:
-                print(failed_log["stderr"])
-
+        _print_failed_install_log(logs)
         self.report(
-            {"ERROR"},
+            {"WARNING"} if bpy.app.background else {"ERROR"},
             "Dependency installation failed. Existing numpy/cv2 may be incompatible. See system console.",
         )
         return {"CANCELLED"}
+
+    def _run_sync(self):
+        state = _new_install_state()
+        try:
+            success, logs = dependency_manager.install_dependencies(
+                progress_callback=_make_progress_callback(state)
+            )
+        except Exception as exc:
+            success = False
+            logs = _exception_log(exc)
+        return self._finish_install(success, logs)
+
+    def _start_modal(self, context):
+        COATOOLS2_OT_InstallPythonDependencies._is_running = True
+        state = _new_install_state()
+        self._install_state = state
+
+        wm = context.window_manager
+        wm.progress_begin(0, 100)
+        self._timer = wm.event_timer_add(0.2, window=context.window)
+        wm.modal_handler_add(self)
+
+        self._thread = threading.Thread(
+            target=self._install_worker, args=(state,), daemon=True
+        )
+        self._thread.start()
+
+        return {"RUNNING_MODAL"}
+
+    def invoke(self, context, event):
+        if COATOOLS2_OT_InstallPythonDependencies._is_running:
+            self.report({"WARNING"}, "Dependency installation is already running.")
+            return {"CANCELLED"}
+        if not _has_modal_ui(context):
+            return self._run_sync()
+        self._start_modal(context)
+        return context.window_manager.invoke_popup(self, width=460)
+
+    def execute(self, context):
+        if COATOOLS2_OT_InstallPythonDependencies._is_running:
+            self.report({"WARNING"}, "Dependency installation is already running.")
+            return {"CANCELLED"}
+        return self._run_sync()
+
+    def draw(self, context):
+        state = getattr(self, "_install_state", _new_install_state())
+        layout = self.layout
+        layout.label(text="Installing numpy/opencv in Blender Python...")
+        layout.label(text=f"Progress: {int(state['progress'])}%")
+        layout.label(text=state["status_message"])
+        if not state["done"]:
+            layout.label(text="This window closes automatically when done.", icon="INFO")
+
+    def modal(self, context, event):
+        if event.type != "TIMER":
+            return {"PASS_THROUGH"}
+
+        state = getattr(self, "_install_state", None)
+        if state is None:
+            COATOOLS2_OT_InstallPythonDependencies._is_running = False
+            return {"CANCELLED"}
+
+        wm = context.window_manager
+        wm.progress_update(int(state["progress"]))
+
+        # refresh UI while popup is visible
+        for area in context.screen.areas:
+            area.tag_redraw()
+
+        if not state["done"]:
+            return {"PASS_THROUGH"}
+
+        wm.progress_end()
+        wm.event_timer_remove(self._timer)
+        COATOOLS2_OT_InstallPythonDependencies._is_running = False
+
+        return self._finish_install(state["success"], state["logs"])


### PR DESCRIPTION
## Summary
- Run dependency installation synchronously in non-interactive/background contexts.
- Keep background install progress in a plain state dictionary instead of writing to operator RNA from the worker thread.
- Avoid popup-only Automesh dependency guidance in headless/background paths.
- Use `INVOKE_DEFAULT` for dependency install buttons in interactive UI.

## Validation
- Blender 5.1.1 `--background --factory-startup --addons coa_tools2`.
- Monkeypatched dependency install path and confirmed `bpy.ops.coa_tools2.install_python_dependencies()` returns `{'FINISHED'}` in background.
- Monkeypatched Automesh dependency state and confirmed missing cv2/numpy returns `{'CANCELLED'}` without exception.
- `git diff --check`.

Fixes #121
Refs #94
