### PR TITLE
fix: initialize Krita docker on Krita 5

### DIFF
--- a/Krita/coa_tools2_exporter/coa_tools2_docker.py
+++ b/Krita/coa_tools2_exporter/coa_tools2_docker.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 
 class COATools2Docker(DockWidget):
     def __init__(self, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         # self.COAToolsExporter = COAToolsExporter()
         self.generateUi()
         ### exporter variables


### PR DESCRIPTION
## Summary
- Fix `COATools2Docker` initialization by removing the extra `self` passed to `DockWidget.__init__`.
- This lets Krita 5.x instantiate the exporter docker normally.

## Validation
- Krita 5.x local run via `krita.com --nosplash`.
- Temporarily installed the fixed plugin into `%APPDATA%\krita\pykrita`, then restored the existing plugin afterward.
- Confirmed `COATools2Docker` instantiates with window title `COA Tools Exporter`.
- Confirmed `exportNode` writes a PNG from a generated validation document.
- `git diff --check`.

Fixes #122
Refs #74
