### PR TITLE
fix: preserve sprite keyframes during action switching

### DIFF
--- a/coa_tools2/functions.py
+++ b/coa_tools2/functions.py
@@ -558,13 +558,90 @@ def create_action(context, item=None, obj=None):
         action = bpy.data.actions[action_name]
 
     action.use_fake_user = True
+    assign_action(obj, action)
+    context.view_layer.update()
+
+
+def get_action_name(item, obj):
+    return item.name + "_" + obj.name
+
+
+def get_animation_objects(context, sprite_object):
+    children = get_children(context, sprite_object, ob_list=[])
+    animation_objects = []
+    if sprite_object.type == "ARMATURE":
+        animation_objects.append(sprite_object)
+    for child in children:
+        animation_objects.append(child)
+    return animation_objects
+
+
+def assign_action(obj, action):
     if obj.animation_data == None:
         obj.animation_data_create()
-    if b_version_smaller_than((4, 4, 0)):
-        obj.animation_data.action = action
-    else:
+    obj.animation_data.action = action
+    if (
+        action != None
+        and not b_version_smaller_than((4, 4, 0))
+        and obj.animation_data.action_slot == None
+        and len(action.slots) > 0
+    ):
         obj.animation_data.action_slot = action.slots[0]
-    context.view_layer.update()
+
+
+def clear_assigned_action(obj):
+    if obj.animation_data != None:
+        obj.animation_data.action = None
+
+
+def is_coa_action_for_object(sprite_object, obj, action):
+    if sprite_object == None or action == None:
+        return False
+
+    for item in sprite_object.coa_tools2.anim_collections:
+        if item.action_collection and action.name == get_action_name(item, obj):
+            return True
+    return False
+
+
+def action_has_fcurves(action):
+    if action == None:
+        return False
+
+    if hasattr(action, "fcurves"):
+        return len(action.fcurves) > 0
+
+    if not hasattr(action, "layers"):
+        return False
+
+    for layer in action.layers:
+        for strip in layer.strips:
+            for slot in action.slots:
+                channelbag = strip.channelbag(slot)
+                if channelbag != None and len(channelbag.fcurves) > 0:
+                    return True
+    return False
+
+
+def register_unassigned_action_collection_keyframes(context, sprite_object, item):
+    if sprite_object == None or item == None or not item.action_collection:
+        return
+
+    for obj in get_animation_objects(context, sprite_object):
+        if obj.animation_data == None or obj.animation_data.action == None:
+            continue
+
+        action = obj.animation_data.action
+        action_name = get_action_name(item, obj)
+        if action.name == action_name or is_coa_action_for_object(sprite_object, obj, action):
+            continue
+        if not action_has_fcurves(action):
+            continue
+        if action_name in bpy.data.actions and bpy.data.actions[action_name] != action:
+            continue
+
+        action.name = action_name
+        action.use_fake_user = True
 
 
 def clear_pose(obj):
@@ -598,18 +675,22 @@ def set_action(context, item=None):
         )
         item = sprite_object.coa_tools2.anim_collections[index]
 
-    children = get_children(context, sprite_object, ob_list=[])
-
-    animation_objects = []
-    if sprite_object.type == "ARMATURE":
-        animation_objects.append(sprite_object)
-    for child in children:
-        animation_objects.append(child)
+    register_unassigned_action_collection_keyframes(context, sprite_object, item)
+    animation_objects = get_animation_objects(context, sprite_object)
 
     for child in animation_objects:
         clear_pose(child)
-        if child.animation_data != None:
-            child.animation_data.action = None
+        action_name = get_action_name(item, child)
+        action = None
+        if action_name in bpy.data.actions:
+            action = bpy.data.actions[action_name]
+
+        if (
+            child.animation_data != None
+            and is_coa_action_for_object(sprite_object, child, child.animation_data.action)
+            and child.animation_data.action != action
+        ):
+            clear_assigned_action(child)
 
         if child.type == "ARMATURE" and item.name == "Restpose":
             for bone in child.pose.bones:
@@ -624,18 +705,9 @@ def set_action(context, item=None):
             not (child.type == "MESH" and item.name == "Restpose")
             and context.scene.coa_tools2.nla_mode == "ACTION"
         ):
-            action_name = item.name + "_" + child.name
-            action = None
-            if action_name in bpy.data.actions:
-                action = bpy.data.actions[action_name]
             if action != None:
                 action.use_fake_user = True
-                if child.animation_data == None:
-                    child.animation_data_create()
-                if b_version_smaller_than((4, 4, 0)):
-                    child.animation_data.action = action
-                else:
-                    child.animation_data.action_slot = action.slots[0]
+                assign_action(child, action)
     context.scene.frame_set(context.scene.frame_current)
     context.view_layer.update()
 

--- a/coa_tools2/operators/animation_handling.py
+++ b/coa_tools2/operators/animation_handling.py
@@ -375,12 +375,7 @@ class COATOOLS2_OT_AddAnimationCollection(bpy.types.Operator):
                 else:
                     action = bpy.data.actions[action_name]
                 action.use_fake_user = True
-                if child.animation_data == None:
-                    child.animation_data_create()
-                if b_version_smaller_than((4, 4, 0)):
-                    child.animation_data.action = action
-                else:
-                    child.animation_data.action_slot = action.slots[0]
+                assign_action(child, action)
 
     def rename_actions(self, action_name):
         for action in bpy.data.actions:
@@ -458,7 +453,7 @@ class COATOOLS2_OT_RemoveAnimationCollection(bpy.types.Operator):
                     child.animation_data != None
                     and child.animation_data.action == bpy.data.actions[action_name]
                 ):
-                    child.animation_data_clear()
+                    clear_assigned_action(child)
                 bpy.data.actions[action_name].use_fake_user = False
                 bpy.data.actions[action_name].user_clear()
                 bpy.data.actions.remove(bpy.data.actions[action_name])

--- a/coa_tools2/properties.py
+++ b/coa_tools2/properties.py
@@ -233,7 +233,18 @@ def set_actions(self, context):
     scene = context.scene
     sprite_object = functions.get_sprite_object(context.active_object)
 
+    if sprite_object == None or len(sprite_object.coa_tools2.anim_collections) == 0:
+        return
+
     index = min(len(sprite_object.coa_tools2.anim_collections) - 1, sprite_object.coa_tools2.anim_collections_index)
+    last_index = sprite_object.coa_tools2.anim_collections_index_last
+    if 0 <= last_index < len(sprite_object.coa_tools2.anim_collections):
+        functions.register_unassigned_action_collection_keyframes(
+            context,
+            sprite_object,
+            sprite_object.coa_tools2.anim_collections[last_index],
+        )
+
     if context.scene.coa_tools2.nla_mode == "ACTION":
         scene.frame_start = sprite_object.coa_tools2.anim_collections[index].frame_start
         scene.frame_end = sprite_object.coa_tools2.anim_collections[index].frame_end
@@ -255,15 +266,26 @@ def set_actions(self, context):
         dirpath = path[:path.rfind("/")]
         final_path = dirpath + "/" + action_name
         context.scene.render.filepath = final_path
+    sprite_object.coa_tools2.anim_collections_index_last = index
 
 
 def set_nla_mode(self, context):
     sprite_object = functions.get_sprite_object(context.active_object)
     children = functions.get_children(context,sprite_object,ob_list=[])
+    if sprite_object != None and len(sprite_object.coa_tools2.anim_collections) > 0:
+        index = min(len(sprite_object.coa_tools2.anim_collections) - 1, sprite_object.coa_tools2.anim_collections_index)
+        functions.register_unassigned_action_collection_keyframes(
+            context,
+            sprite_object,
+            sprite_object.coa_tools2.anim_collections[index],
+        )
     if self.nla_mode == "NLA":
         for child in children:
-            if child.animation_data != None:
-                child.animation_data.action = None
+            if (
+                child.animation_data != None
+                and functions.is_coa_action_for_object(sprite_object, child, child.animation_data.action)
+            ):
+                functions.clear_assigned_action(child)
         context.scene.frame_start = context.scene.coa_tools2.frame_start
         context.scene.frame_end = context.scene.coa_tools2.frame_end
 
@@ -464,6 +486,7 @@ class ObjectProperties(bpy.types.PropertyGroup):
     edit_mesh: BoolProperty(default=False, update=change_edit_mode)
 
     anim_collections_index: IntProperty(update=set_actions)
+    anim_collections_index_last: IntProperty(default=-1)
     copy_data_from_mesh: PointerProperty(
         type=bpy.types.Mesh, name="Copy Data From Mesh Object"
     )


### PR DESCRIPTION
## Summary

Preserve sprite keyframes when switching animation collections in the add-on UI.

## Root Cause

The action switching path could clear or detach actions unconditionally. Directly inserted sprite keyframes that had not yet been renamed into COA action collection form could become orphaned or effectively lost when the selected animation collection changed.

## Changes

- Add helpers for assigning and clearing actions consistently.
- Track the previously selected animation collection index.
- Register unassigned direct keyframe actions into the current animation collection before switching away.
- Support Blender 4.4+ action layers/channelbags when checking whether an action contains fcurves.

## Validation

Validated in Blender 5.1.1 with a clean user directory. Created a sample sprite, inserted a direct `location` keyframe, switched from the active animation collection to `NO ACTION`, switched back, and confirmed the `Walk_<sprite>` action, fcurves, and sprite action assignment were preserved.

Fixes #34
