### PR TITLE
ci: add addon validation workflow

### DIFF
--- a/.github/workflows/blender-addon-validation.yml
+++ b/.github/workflows/blender-addon-validation.yml
@@ -1,0 +1,67 @@
+name: blender-addon-validation
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+  push:
+    branches:
+      - master
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  addon_sanity:
+    name: Add-on syntax and package sanity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate add-on files
+        run: python scripts/validate_blender_addon.py
+      - name: Check add-on metadata versions
+        run: python scripts/sync_blender_addon_version.py --check-consistent
+
+  blender_smoke:
+    name: Blender add-on smoke
+    runs-on: ubuntu-latest
+    needs: addon_sanity
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Blender from Ubuntu packages
+        id: install_blender
+        shell: bash
+        run: |
+          set -euo pipefail
+          if sudo apt-get update && sudo apt-get install -y blender; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Blender package is unavailable on this runner; skipping smoke."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Prepare isolated Blender add-on path
+        if: steps.install_blender.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/blender-user-scripts/addons"
+          cp -R coa_tools2 "$RUNNER_TEMP/blender-user-scripts/addons/coa_tools2"
+      - name: Run add-on enable smoke
+        if: steps.install_blender.outputs.available == 'true'
+        shell: bash
+        env:
+          BLENDER_USER_SCRIPTS: ${{ runner.temp }}/blender-user-scripts
+          BLENDER_USER_CONFIG: ${{ runner.temp }}/blender-user-config
+          BLENDER_USER_DATAFILES: ${{ runner.temp }}/blender-user-datafiles
+        run: |
+          set -euo pipefail
+          mkdir -p "$BLENDER_USER_CONFIG" "$BLENDER_USER_DATAFILES"
+          blender --version
+          blender --background --factory-startup --python scripts/blender_smoke_test.py

--- a/scripts/blender_smoke_test.py
+++ b/scripts/blender_smoke_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Enable and disable the add-on inside Blender using an isolated user path."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import addon_utils
+import bpy
+
+
+MODULE_NAME = "coa_tools2"
+ROOT = Path(__file__).resolve().parents[1]
+CHECKOUT_ADDON_DIR = (ROOT / MODULE_NAME).resolve()
+
+
+def load_required_blender_version() -> tuple[int, int, int]:
+    init_file = ROOT / MODULE_NAME / "__init__.py"
+    tree = ast.parse(init_file.read_text(encoding="utf-8"), filename=str(init_file))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "bl_info"
+            for target in node.targets
+        ):
+            continue
+        bl_info = ast.literal_eval(node.value)
+        version = bl_info.get("blender")
+        if (
+            isinstance(version, tuple)
+            and len(version) == 3
+            and all(isinstance(part, int) for part in version)
+        ):
+            return version
+    raise RuntimeError("Could not read bl_info['blender'].")
+
+
+def path_is_inside(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def main() -> int:
+    required_version = load_required_blender_version()
+    if bpy.app.version < required_version:
+        print(
+            "Skipping add-on enable smoke: "
+            f"Blender {bpy.app.version_string} is older than {required_version}."
+        )
+        return 0
+
+    module = addon_utils.enable(MODULE_NAME, default_set=True, persistent=False)
+    if module is None:
+        raise RuntimeError(f"addon_utils.enable({MODULE_NAME!r}) returned None.")
+
+    module_file = Path(module.__file__).resolve()
+    if path_is_inside(module_file, CHECKOUT_ADDON_DIR):
+        raise RuntimeError(
+            "Smoke test loaded the checkout add-on directly. "
+            "Copy it to an isolated BLENDER_USER_SCRIPTS/addons path first."
+        )
+
+    loaded, enabled = addon_utils.check(MODULE_NAME)
+    if not loaded or not enabled:
+        raise RuntimeError(
+            f"Add-on did not enable cleanly: loaded={loaded}, enabled={enabled}"
+        )
+
+    if MODULE_NAME not in {addon.module for addon in bpy.context.preferences.addons}:
+        raise RuntimeError("Add-on preferences entry was not registered.")
+
+    addon_utils.disable(MODULE_NAME, default_set=True)
+    loaded, enabled = addon_utils.check(MODULE_NAME)
+    if loaded or enabled:
+        raise RuntimeError(
+            f"Add-on did not disable cleanly: loaded={loaded}, enabled={enabled}"
+        )
+
+    print(f"{MODULE_NAME} Blender enable/disable smoke OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"Blender smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/validate_blender_addon.py
+++ b/scripts/validate_blender_addon.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Repository-level sanity checks for the COA Tools 2 Blender add-on."""
+
+from __future__ import annotations
+
+import ast
+import re
+import tempfile
+import zipfile
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Blender/Python 3.10 fallback.
+    tomllib = None
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADDON_DIR = ROOT / "coa_tools2"
+MANIFEST_FILE = ADDON_DIR / "blender_manifest.toml"
+INIT_FILE = ADDON_DIR / "__init__.py"
+RELEASE_DIRS = ("GIMP", "Krita", "coa_tools2", "Photoshop", "Godot")
+PYTHON_CHECK_ROOTS = ("coa_tools2", "Krita", "GIMP", "scripts")
+ZIP_REQUIRED_FILES = (
+    "coa_tools2/__init__.py",
+    "coa_tools2/blender_manifest.toml",
+    "coa_tools2/icons/coa_tools.draw_bone.dat",
+    "coa_tools2/icons/coa_tools.draw_polygon.dat",
+)
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def load_manifest() -> dict:
+    if tomllib is not None:
+        return tomllib.loads(MANIFEST_FILE.read_text(encoding="utf-8"))
+
+    data: dict[str, object] = {}
+    for raw_line in MANIFEST_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = [part.strip() for part in line.split("=", 1)]
+        if value.startswith('"') and value.endswith('"'):
+            data[key] = value[1:-1]
+        elif value.startswith("[") and value.endswith("]"):
+            data[key] = [
+                item.strip().strip('"')
+                for item in value[1:-1].split(",")
+                if item.strip()
+            ]
+    return data
+
+
+def load_bl_info() -> dict:
+    tree = ast.parse(INIT_FILE.read_text(encoding="utf-8"), filename=str(INIT_FILE))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(
+            isinstance(target, ast.Name) and target.id == "bl_info"
+            for target in node.targets
+        ):
+            value = ast.literal_eval(node.value)
+            if isinstance(value, dict):
+                return value
+    raise SystemExit(f"Missing bl_info in {INIT_FILE}")
+
+
+def version_tuple_to_text(version: object) -> str:
+    if (
+        isinstance(version, tuple)
+        and len(version) == 3
+        and all(isinstance(part, int) for part in version)
+    ):
+        return ".".join(str(part) for part in version)
+    raise SystemExit(f"Invalid bl_info version: {version!r}")
+
+
+def check_python_syntax() -> None:
+    files: list[Path] = []
+    for root_name in PYTHON_CHECK_ROOTS:
+        root = ROOT / root_name
+        if root.exists():
+            files.extend(sorted(root.rglob("*.py")))
+
+    for path in files:
+        source = path.read_text(encoding="utf-8-sig")
+        compile(source, str(path), "exec")
+
+    print(f"Compiled {len(files)} Python files.")
+
+
+def check_metadata() -> None:
+    manifest = load_manifest()
+    bl_info = load_bl_info()
+
+    required_manifest = {
+        "id": "coa_tools2",
+        "type": "add-on",
+        "name": "COA Tools 2",
+    }
+    for key, expected in required_manifest.items():
+        actual = manifest.get(key)
+        if actual != expected:
+            raise SystemExit(
+                f"{MANIFEST_FILE}: expected {key}={expected!r}, found {actual!r}"
+            )
+
+    manifest_version = manifest.get("version")
+    if not isinstance(manifest_version, str) or not VERSION_RE.match(manifest_version):
+        raise SystemExit(f"{MANIFEST_FILE}: invalid version {manifest_version!r}")
+
+    bl_info_version = version_tuple_to_text(bl_info.get("version"))
+    if bl_info_version != manifest_version:
+        raise SystemExit(
+            "Version mismatch: "
+            f"bl_info={bl_info_version}, manifest={manifest_version}"
+        )
+
+    blender_min = manifest.get("blender_version_min")
+    if not isinstance(blender_min, str) or not VERSION_RE.match(blender_min):
+        raise SystemExit(f"{MANIFEST_FILE}: invalid blender_version_min {blender_min!r}")
+
+    print(
+        "Metadata OK: "
+        f"version {manifest_version}, Blender minimum {blender_min}."
+    )
+
+
+def check_release_roots() -> None:
+    for dirname in RELEASE_DIRS:
+        path = ROOT / dirname
+        if not path.is_dir():
+            raise SystemExit(f"Missing release directory: {path}")
+        if not any(path.iterdir()):
+            raise SystemExit(f"Release directory is empty: {path}")
+    print("Release roots OK.")
+
+
+def should_skip_from_zip(path: Path) -> bool:
+    parts = set(path.parts)
+    return (
+        "__pycache__" in parts
+        or path.suffix in {".pyc", ".pyo"}
+        or path.name == "updater_status.json"
+    )
+
+
+def check_addon_zip_layout() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zip_path = Path(tmpdir) / "coa_tools2.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as archive:
+            for path in sorted(ADDON_DIR.rglob("*")):
+                if path.is_file() and not should_skip_from_zip(path.relative_to(ROOT)):
+                    archive.write(path, path.relative_to(ROOT).as_posix())
+
+        with zipfile.ZipFile(zip_path) as archive:
+            names = set(archive.namelist())
+            for required in ZIP_REQUIRED_FILES:
+                if required not in names:
+                    raise SystemExit(f"Add-on zip missing required file: {required}")
+            if any(name.startswith("/") or ".." in Path(name).parts for name in names):
+                raise SystemExit("Add-on zip contains unsafe path entries.")
+
+    print("Add-on zip layout OK.")
+
+
+def main() -> int:
+    check_python_syntax()
+    check_metadata()
+    check_release_roots()
+    check_addon_zip_layout()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a repository-specific GitHub Actions workflow for Blender add-on validation.

## Root Cause

The repository did not have CI coverage that could catch add-on registration issues, Blender API compatibility problems, or release layout mistakes before manual review.

## Changes

- Add `.github/workflows/blender-addon-validation.yml`.
- Add `scripts/validate_blender_addon.py` for Python compilation, metadata, release root, and zip layout checks.
- Add `scripts/blender_smoke_test.py` for Blender add-on enable/disable smoke testing.
- Keep static validation mandatory while allowing the Blender smoke job to skip cleanly if Blender is unavailable on the runner.

## Validation

Ran `uv run python scripts/validate_blender_addon.py` locally and confirmed Python compilation, metadata, release root, and zip layout checks pass.

Ran the Blender smoke test locally with Blender 5.1.1 and a clean user directory using the same add-on layout as the workflow. The smoke test reported `coa_tools2 Blender enable/disable smoke OK.`

GitHub Actions also passed both workflow jobs on this PR:

- `Add-on syntax and package sanity`
- `Blender add-on smoke`

Fixes #123
