### PR TITLE
fix: redirect direct sprite edit mode

### DIFF
--- a/coa_tools2/__init__.py
+++ b/coa_tools2/__init__.py
@@ -274,6 +274,133 @@ classes = (
 
 addon_keymaps = []
 
+_DIRECT_EDIT_REDIRECT_TARGET = "coa_tools2_direct_edit_redirect_target"
+_DIRECT_EDIT_REDIRECT_SUPPRESS = "coa_tools2_direct_edit_redirect_suppress"
+
+
+def _get_parent_sprite_object(obj):
+    while obj is not None:
+        try:
+            if "sprite_object" in obj.coa_tools2:
+                return obj
+        except ReferenceError:
+            return None
+        obj = obj.parent
+    return None
+
+
+def _is_direct_edit_redirect_candidate(context, obj):
+    wm = context.window_manager if context is not None else None
+    if (
+        wm is None
+        or bool(wm.get("coa_tools2_edit_mesh_modal_running", False))
+        or bool(wm.get(_DIRECT_EDIT_REDIRECT_SUPPRESS, False))
+        or wm.get(_DIRECT_EDIT_REDIRECT_TARGET, "") != ""
+    ):
+        return False
+
+    if (
+        obj is None
+        or obj.type != "MESH"
+        or obj.mode != "EDIT"
+        or obj.name == "COA TEXTURE PREVIEW"
+        or "coa_base_sprite" not in obj.vertex_groups
+    ):
+        return False
+
+    sprite_object = _get_parent_sprite_object(obj)
+    if sprite_object is None:
+        return False
+
+    try:
+        return not (
+            sprite_object.coa_tools2.edit_mesh
+            or sprite_object.coa_tools2.edit_armature
+            or sprite_object.coa_tools2.edit_weights
+            or sprite_object.coa_tools2.edit_shapekey
+        )
+    except ReferenceError:
+        return False
+
+
+def _get_view3d_override(context):
+    screen = context.screen if context is not None else None
+    if screen is None:
+        return None
+
+    for area in screen.areas:
+        if area.type != "VIEW_3D":
+            continue
+        region = next(
+            (region for region in area.regions if region.type == "WINDOW"), None
+        )
+        space = next((space for space in area.spaces if space.type == "VIEW_3D"), None)
+        if region is None or space is None:
+            continue
+
+        override = {
+            "area": area,
+            "region": region,
+            "space_data": space,
+        }
+        if context.window is not None:
+            override["window"] = context.window
+        return override
+
+    return None
+
+
+def _enter_coa_edit_mesh_from_direct_edit():
+    context = bpy.context
+    wm = context.window_manager if context is not None else None
+    if wm is None:
+        return None
+
+    target_name = wm.get(_DIRECT_EDIT_REDIRECT_TARGET, "")
+    if _DIRECT_EDIT_REDIRECT_TARGET in wm:
+        del wm[_DIRECT_EDIT_REDIRECT_TARGET]
+
+    if target_name not in bpy.data.objects:
+        return None
+
+    obj = bpy.data.objects[target_name]
+    if context.active_object != obj or not _is_direct_edit_redirect_candidate(
+        context, obj
+    ):
+        return None
+
+    wm[_DIRECT_EDIT_REDIRECT_SUPPRESS] = True
+    try:
+        bpy.ops.object.mode_set(mode="OBJECT")
+        for selected in list(context.selected_objects):
+            selected.select_set(False)
+        obj.select_set(True)
+        context.view_layer.objects.active = obj
+        override = _get_view3d_override(context)
+        if override is not None:
+            with context.temp_override(**override):
+                bpy.ops.coa_tools2.edit_mesh(mode="EDIT_MESH")
+        else:
+            bpy.ops.coa_tools2.edit_mesh(mode="EDIT_MESH")
+    except Exception:
+        traceback.print_exc()
+    finally:
+        if _DIRECT_EDIT_REDIRECT_SUPPRESS in wm:
+            del wm[_DIRECT_EDIT_REDIRECT_SUPPRESS]
+
+    return None
+
+
+@persistent
+def redirect_direct_sprite_mesh_edit_mode(scene, depsgraph):
+    context = bpy.context
+    obj = context.active_object if context is not None else None
+    if not _is_direct_edit_redirect_candidate(context, obj):
+        return
+
+    context.window_manager[_DIRECT_EDIT_REDIRECT_TARGET] = obj.name
+    bpy.app.timers.register(_enter_coa_edit_mesh_from_direct_edit, first_interval=0.0)
+
 
 def register_keymaps():
     kc = bpy.context.window_manager.keyconfigs.addon
@@ -331,6 +458,7 @@ def register():
     bpy.app.handlers.depsgraph_update_pre.append(outliner.create_outliner_items)
     bpy.app.handlers.frame_change_post.append(update_properties)
     bpy.app.handlers.depsgraph_update_post.append(update_properties)
+    bpy.app.handlers.depsgraph_update_post.append(redirect_direct_sprite_mesh_edit_mode)
     bpy.app.handlers.load_post.append(check_view_2D_3D)
     bpy.app.handlers.load_post.append(check_for_deprecated_data)
     bpy.app.handlers.load_post.append(check_for_old_coatools)
@@ -355,6 +483,10 @@ def unregister():
     bpy.app.handlers.depsgraph_update_pre.remove(outliner.create_outliner_items)
     bpy.app.handlers.frame_change_post.remove(update_properties)
     bpy.app.handlers.depsgraph_update_post.remove(update_properties)
+    if redirect_direct_sprite_mesh_edit_mode in bpy.app.handlers.depsgraph_update_post:
+        bpy.app.handlers.depsgraph_update_post.remove(
+            redirect_direct_sprite_mesh_edit_mode
+        )
     bpy.app.handlers.load_post.remove(check_view_2D_3D)
     bpy.app.handlers.load_post.remove(check_for_deprecated_data)
     bpy.app.handlers.load_post.remove(check_for_old_coatools)

--- a/coa_tools2/operators/edit_mesh.py
+++ b/coa_tools2/operators/edit_mesh.py
@@ -1890,7 +1890,6 @@ class COATOOLS2_OT_DrawContour(bpy.types.Operator):
 
     def cancel(self, context):
         context.window_manager["coa_tools2_edit_mesh_modal_running"] = False
-        return {"CANCELLED"}
 
     def draw_callback_text(self):
         obj = bpy.context.active_object


### PR DESCRIPTION
## Summary

Redirect direct Blender Edit Mode entry on COA sprite meshes into the COA Edit Mesh workflow.

## Root Cause

Users could press `Tab` or use Blender's normal mode menu on a COA sprite mesh and enter raw mesh edit mode directly. That bypassed COA Tools' texture projection/edit mesh setup and could leave the sprite in a free deformation state or trigger context-sensitive operator errors.

## Changes

- Add a depsgraph/timer-based redirect when a COA sprite mesh enters raw Edit Mode directly.
- Avoid redirecting while COA edit modes are already active, while the edit mesh modal operator is running, or for non-COA meshes.
- Run the COA Edit Mesh operator with a View3D context override when available.
- Adjust the edit mesh modal `cancel()` callback for Blender 5.1's expected return behavior.

## Validation

- `uv run python scripts/validate_blender_addon.py`
- Blender 5.1.1 clean user directory, normal UI launch: enabled the add-on, created a sample sprite, selected the sprite mesh, entered raw Edit Mode with `bpy.ops.object.mode_set(mode="EDIT")`, and confirmed it redirected to COA Edit Mesh with texture preview and modal state active.
- Confirmed the Blender 5.1 modal cancel callback no longer reports `expected ... cancel to return None`.

Fixes #9
