### PR TITLE
fix: stabilize driven slot index updates

### DIFF
--- a/coa_tools2/__init__.py
+++ b/coa_tools2/__init__.py
@@ -88,6 +88,16 @@ from .operators.exporter import export_creature
 
 import traceback
 
+_slot_index_cache = {}
+_updating_properties = False
+
+
+def _slot_index_cache_key(obj):
+    try:
+        return obj.as_pointer()
+    except ReferenceError:
+        return None
+
 
 class COATools2Preferences(bpy.types.AddonPreferences):
     bl_idname = __package__
@@ -401,25 +411,50 @@ def set_shading(dummy):
 
 @persistent
 def update_properties(scene, depsgraph):
+    global _updating_properties
+    if _updating_properties:
+        return
+
+    _updating_properties = True
     context = bpy.context
-    for obj in bpy.data.objects:
-        obj_eval = obj.evaluated_get(depsgraph)
+    try:
+        for obj in bpy.data.objects:
+            obj_eval = obj.evaluated_get(depsgraph)
 
-        if obj_eval.coa_tools2.slot_index != obj_eval.coa_tools2.slot_index_last:
-            change_slot_mesh_data(bpy.context, obj, obj_eval)
-            obj.coa_tools2.slot_index_last = obj_eval.coa_tools2.slot_index
+            if obj.type == "MESH" and obj.coa_tools2.type == "SLOT":
+                slot_index = get_clamped_slot_index(obj, obj_eval)
+                if slot_index is not None:
+                    slot = obj.coa_tools2.slot[slot_index]
+                    cache_key = _slot_index_cache_key(obj)
+                    cache_index = _slot_index_cache.get(cache_key)
+                    if (
+                        slot.mesh is not None
+                        and (cache_index != slot_index or obj.data != slot.mesh)
+                    ):
+                        change_slot_mesh_data(
+                            context,
+                            obj,
+                            obj_eval,
+                            clamp_property=False,
+                            sync_active=False,
+                            alpha=obj_eval.coa_tools2.alpha,
+                            modulate_color=obj_eval.coa_tools2.modulate_color,
+                        )
+                    _slot_index_cache[cache_key] = slot_index
 
-        if obj_eval.coa_tools2.alpha != obj_eval.coa_tools2.alpha_last:
-            set_alpha(obj, context, obj_eval.coa_tools2.alpha)
-            obj.coa_tools2.alpha_last = obj_eval.coa_tools2.alpha
+            if obj_eval.coa_tools2.alpha != obj_eval.coa_tools2.alpha_last:
+                set_alpha(obj, context, obj_eval.coa_tools2.alpha)
+                obj.coa_tools2.alpha_last = obj_eval.coa_tools2.alpha
 
-        if (
-            obj_eval.coa_tools2.modulate_color
-            != obj_eval.coa_tools2.modulate_color_last
-        ):
-            set_modulate_color(obj, context, obj_eval.coa_tools2.modulate_color)
-            obj.coa_tools2.modulate_color_last = obj_eval.coa_tools2.modulate_color
+            if (
+                obj_eval.coa_tools2.modulate_color
+                != obj_eval.coa_tools2.modulate_color_last
+            ):
+                set_modulate_color(obj, context, obj_eval.coa_tools2.modulate_color)
+                obj.coa_tools2.modulate_color_last = obj_eval.coa_tools2.modulate_color
 
-        if obj_eval.coa_tools2.z_value != obj_eval.coa_tools2.z_value_last:
-            set_z_value(context, obj, obj_eval.coa_tools2.z_value)
-            obj.coa_tools2.z_value_last = obj_eval.coa_tools2.z_value
+            if obj_eval.coa_tools2.z_value != obj_eval.coa_tools2.z_value_last:
+                set_z_value(context, obj, obj_eval.coa_tools2.z_value)
+                obj.coa_tools2.z_value_last = obj_eval.coa_tools2.z_value
+    finally:
+        _updating_properties = False

--- a/coa_tools2/functions.py
+++ b/coa_tools2/functions.py
@@ -971,56 +971,96 @@ def set_z_value(context, obj, z):
 
 def set_modulate_color(obj, context, color):
     if obj.type == "MESH":
+        if obj.active_material is None:
+            return
         coa_material_node = None
         node_tree = obj.active_material.node_tree
         if node_tree != None:
             for node in node_tree.nodes:
                 if (
                     node.type == "GROUP"
+                    and node.node_tree is not None
                     and node.node_tree.name == CONSTANTS.COA_NODE_GROUP_NAME
                 ):
                     coa_material_node = node
                     break
         if coa_material_node != None:
-            coa_material_node.inputs["Modulate Color"].default_value[:3] = color
+            color_input = coa_material_node.inputs.get("Modulate Color")
+            if (
+                color_input is not None
+                and tuple(color_input.default_value[:3]) != tuple(color)
+            ):
+                color_input.default_value[:3] = color
 
 
 def set_alpha(obj, context, alpha):
     if obj.type == "MESH":
+        if obj.active_material is None:
+            return
         coa_material_node = None
         node_tree = obj.active_material.node_tree
         if node_tree != None:
             for node in node_tree.nodes:
                 if (
                     node.type == "GROUP"
+                    and node.node_tree is not None
                     and node.node_tree.name == CONSTANTS.COA_NODE_GROUP_NAME
                 ):
                     coa_material_node = node
                     break
         if coa_material_node != None:
-            coa_material_node.inputs["Alpha"].default_value = alpha
+            alpha_input = coa_material_node.inputs.get("Alpha")
+            if alpha_input is not None and alpha_input.default_value != alpha:
+                alpha_input.default_value = alpha
 
 
-def change_slot_mesh_data(context, obj, obj_eval=None):
-    if len(obj.coa_tools2.slot) > 0:
-        slot_len = len(obj.coa_tools2.slot) - 1
-        new_index = min(
-            obj.coa_tools2.slot_index, max(0, len(obj.coa_tools2.slot) - 1)
-        )
-        if obj.coa_tools2.slot_index != new_index:
-            object.__setattr__(obj.coa_tools2, "_lock_slot_index_update", True)
-            try:
-                obj.coa_tools2.slot_index = new_index
-            finally:
-                object.__setattr__(obj.coa_tools2, "_lock_slot_index_update", False)
-        if obj_eval == None:
-            obj_eval = obj
-        idx = max(min(obj_eval.coa_tools2.slot_index, len(obj.coa_tools2.slot) - 1), 0)
+def get_clamped_slot_index(obj, obj_eval=None):
+    if obj is None or not hasattr(obj, "coa_tools2"):
+        return None
+    if len(obj.coa_tools2.slot) == 0:
+        return None
 
-        slot = obj.coa_tools2.slot[idx]
-        obj = slot.id_data
+    source_obj = obj_eval if obj_eval is not None else obj
+    try:
+        index = int(source_obj.coa_tools2.slot_index)
+    except (AttributeError, TypeError, ValueError):
+        index = 0
+    return max(0, min(index, len(obj.coa_tools2.slot) - 1))
+
+
+def change_slot_mesh_data(
+    context,
+    obj,
+    obj_eval=None,
+    *,
+    clamp_property=True,
+    sync_active=True,
+    alpha=None,
+    modulate_color=None,
+):
+    idx = get_clamped_slot_index(obj, obj_eval)
+    if idx is None:
+        return False
+
+    if clamp_property and obj_eval is None and obj.coa_tools2.slot_index != idx:
+        object.__setattr__(obj.coa_tools2, "_lock_slot_index_update", True)
+        try:
+            obj.coa_tools2.slot_index = idx
+        finally:
+            object.__setattr__(obj.coa_tools2, "_lock_slot_index_update", False)
+
+    slot = obj.coa_tools2.slot[idx]
+    if slot.mesh is None:
+        return False
+
+    obj = slot.id_data
+    if obj.data != slot.mesh:
         obj.data = slot.mesh
-        set_alpha(obj, context, obj.coa_tools2.alpha)
+    set_alpha(obj, context, obj.coa_tools2.alpha if alpha is None else alpha)
+    if modulate_color is not None:
+        set_modulate_color(obj, context, modulate_color)
+
+    if sync_active:
         for slot2 in obj.coa_tools2.slot:
             if slot != slot2 and slot2.active:
                 object.__setattr__(slot2, "_lock_active_update", True)
@@ -1034,13 +1074,16 @@ def change_slot_mesh_data(context, obj, obj_eval=None):
                     slot2.active = True
                 finally:
                     object.__setattr__(slot2, "_lock_active_update", False)
-        if "coa_base_sprite" in obj.modifiers:
-            if slot.mesh.coa_tools2.hide_base_sprite:
-                obj.modifiers["coa_base_sprite"].show_render = True
-                obj.modifiers["coa_base_sprite"].show_viewport = True
-            else:
-                obj.modifiers["coa_base_sprite"].show_render = False
-                obj.modifiers["coa_base_sprite"].show_viewport = False
+
+    if "coa_base_sprite" in obj.modifiers:
+        hide_base_sprite = bool(slot.mesh.coa_tools2.hide_base_sprite)
+        modifier = obj.modifiers["coa_base_sprite"]
+        if modifier.show_render != hide_base_sprite:
+            modifier.show_render = hide_base_sprite
+        if modifier.show_viewport != hide_base_sprite:
+            modifier.show_viewport = hide_base_sprite
+
+    return True
 
 
 def display_children(self, context, obj):

--- a/coa_tools2/properties.py
+++ b/coa_tools2/properties.py
@@ -155,14 +155,25 @@ def enum_sprite_previews(self, context):
     if self.type == "SLOT":
         for i, slot in enumerate(self.slot):
             if slot.mesh != None:
+                if len(slot.mesh.materials) == 0:
+                    continue
                 mat = slot.mesh.materials[0]
+                if mat is None or mat.node_tree is None:
+                    continue
                 for node in mat.node_tree.nodes:
                     if node.label == "COA Material":
-                        tex_node = node.inputs["Texture Color"].links[0].from_node
+                        texture_input = node.inputs.get("Texture Color")
+                        if texture_input is None:
+                            continue
+                        links = texture_input.links
+                        if len(links) == 0:
+                            continue
+                        tex_node = links[0].from_node
                         if tex_node != None:
-                            img = tex_node.image
-                            icon = bpy.types.UILayout.icon(img)
-                            enum_items.append((str(i), slot.mesh.name, "", icon, i))
+                            img = getattr(tex_node, "image", None)
+                            if img != None:
+                                icon = bpy.types.UILayout.icon(img)
+                                enum_items.append((str(i), slot.mesh.name, "", icon, i))
 
     return enum_items
 

--- a/coa_tools2/ui.py
+++ b/coa_tools2/ui.py
@@ -239,13 +239,16 @@ class COATOOLS2_PT_ObjectProperties(bpy.types.Panel):
 
             col.prop(obj, "name", text="", icon=icon)
             if obj.type == "MESH" and obj.coa_tools2.type == "SLOT":
-                index = min(len(obj.coa_tools2.slot) - 1, obj.coa_tools2.slot_index)
-                col.prop(
-                    obj.coa_tools2.slot[index].mesh,
-                    "name",
-                    text="",
-                    icon="OUTLINER_DATA_MESH",
-                )
+                index = functions.get_clamped_slot_index(obj)
+                if index is not None:
+                    slot_mesh = obj.coa_tools2.slot[index].mesh
+                    if slot_mesh is not None:
+                        col.prop(
+                            slot_mesh,
+                            "name",
+                            text="",
+                            icon="OUTLINER_DATA_MESH",
+                        )
             if obj.type == "ARMATURE":
                 row = layout.row(align=True)
                 if context.active_bone != None:


### PR DESCRIPTION
## Summary

Stabilize slot mesh updates when `coa_tools2.slot_index` is driven or animated through the dependency graph.

## Root Cause

The previous update path compared the evaluated slot index with a stored property and then wrote back active slot state while dependency graph evaluation was already in progress. Driven slot index updates can therefore re-enter slot update logic or leave the rendered object data out of sync with the evaluated slot index.

## Changes

- Add clamped slot index helpers that can read from evaluated objects.
- Track slot mesh application with an internal cache instead of relying only on `slot_index_last` writes.
- Avoid active slot UI synchronization from the dependency graph render/playback path.
- Reapply evaluated alpha/modulate values when the driven slot index swaps mesh data.
- Add defensive material and slot preview guards for missing materials, missing node trees, missing texture links, and non-image linked nodes.

## Validation

- `uv run python scripts/validate_blender_addon.py`
- Blender 5.1.1 clean user directory: built a minimal SLOT object from three imported sample sprites, added scene-frame drivers to `coa_tools2.slot_index` and `coa_tools2.alpha`, advanced frames `0..5`, and confirmed `slot_obj.data` matched the evaluated slot mesh and evaluated alpha was applied to the active COA material.
- Blender 5.1.1 clean user directory: confirmed broken slot preview entries with no material / non-image nodes do not raise exceptions.

## Notes

A direct render validation was attempted, but the local render path timed out during this pass. This PR therefore references the issue for review instead of auto-closing it.

Refs #62
