### PR TITLE
fix: resolve updater add-on source zips

### DIFF
--- a/coa_tools2/addon_updater.py
+++ b/coa_tools2/addon_updater.py
@@ -774,6 +774,98 @@ class Singleton_updater(object):
 
         self.reload_addon()
 
+    def _is_addon_source_path(self, path):
+        return path != None and os.path.isfile(os.path.join(path, "__init__.py"))
+
+    def _source_subfolder_candidates(self):
+        candidates = []
+        for value in [self._subfolder_path, self._addon]:
+            if value in [None, ""]:
+                continue
+            value = os.path.normpath(value)
+            if os.path.isabs(value):
+                continue
+            if value in [os.curdir, os.pardir] or os.pardir in value.split(os.sep):
+                continue
+            if value not in candidates:
+                candidates.append(value)
+        return candidates
+
+    def _resolve_unique_source_match(self, matches):
+        unique_matches = []
+        for path in matches:
+            path = os.path.abspath(path)
+            if path not in unique_matches:
+                unique_matches.append(path)
+
+        if len(unique_matches) == 1:
+            return unique_matches[0]
+        if len(unique_matches) > 1:
+            return False
+        return None
+
+    def _resolve_addon_source_path(self, source_root):
+        if self._is_addon_source_path(source_root):
+            return source_root
+
+        source_root = os.path.abspath(source_root)
+        search_roots = [source_root]
+        for name in sorted(os.listdir(source_root)):
+            path = os.path.join(source_root, name)
+            if os.path.isdir(path):
+                search_roots.append(path)
+
+        candidates = self._source_subfolder_candidates()
+        for candidate in candidates:
+            matches = []
+            for root in search_roots:
+                path = os.path.abspath(os.path.join(root, candidate))
+                if os.path.commonpath([source_root, path]) != source_root:
+                    continue
+                if self._is_addon_source_path(path):
+                    matches.append(path)
+
+            match = self._resolve_unique_source_match(matches)
+            if match is False:
+                return None
+            if match is not None:
+                return match
+
+        addon_name = os.path.normcase(self._addon) if self._addon else None
+        addon_matches = []
+        candidate_matches = {candidate: [] for candidate in candidates}
+        for root, dirs, files in os.walk(source_root):
+            dirs.sort()
+            if "__init__.py" not in files:
+                continue
+
+            relpath = os.path.normpath(os.path.relpath(root, source_root))
+            relpath_cmp = os.path.normcase(relpath)
+            for candidate in candidates:
+                candidate_cmp = os.path.normcase(candidate)
+                if relpath_cmp == candidate_cmp or relpath_cmp.endswith(
+                    os.sep + candidate_cmp
+                ):
+                    candidate_matches[candidate].append(root)
+
+            if addon_name and os.path.normcase(os.path.basename(root)) == addon_name:
+                addon_matches.append(root)
+
+        for candidate in candidates:
+            match = self._resolve_unique_source_match(candidate_matches[candidate])
+            if match is False:
+                return None
+            if match is not None:
+                return match
+
+        match = self._resolve_unique_source_match(addon_matches)
+        if match is False:
+            return None
+        if match is not None:
+            return match
+
+        return None
+
     def unpack_staged_zip(self, clean=False):
 
         if os.path.isfile(self._source_zip) == False:
@@ -803,22 +895,20 @@ class Singleton_updater(object):
         if self._verbose:
             print("Extracted source")
 
-        # either directly in root of zip, or one folder level deep
-        unpath = os.path.join(self._updater_path, "source")
-        if os.path.isfile(os.path.join(unpath, "__init__.py")) == False:
-            dirlist = os.listdir(unpath)
-            if len(dirlist) > 0:
-                unpath = os.path.join(unpath, dirlist[0], self._subfolder_path)
+        source_root = os.path.join(self._updater_path, "source")
+        unpath = self._resolve_addon_source_path(source_root)
+        if unpath == None:
+            if self._verbose:
+                print("not a valid addon found")
+                print("Paths:")
+                print(os.listdir(source_root))
+                print("Expected addon paths:")
+                print(self._source_subfolder_candidates())
 
-            # smarter check for additional sub folders for a single folder
-            # containing __init__.py
-            if os.path.isfile(os.path.join(unpath, "__init__.py")) == False:
-                if self._verbose:
-                    print("not a valid addon found")
-                    print("Paths:")
-                    print(dirlist)
+            raise ValueError("__init__ file not found in new source")
 
-                raise ValueError("__init__ file not found in new source")
+        if self._verbose:
+            print("Resolved addon source path: " + unpath)
 
         # now commence merging in the two locations:
         # note this MAY not be accurate, as updater files could be placed elsewhere

--- a/tests/test_addon_updater_zip_source.py
+++ b/tests/test_addon_updater_zip_source.py
@@ -1,0 +1,141 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+import zipfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ADDON_UPDATER_PATH = REPO_ROOT / "coa_tools2" / "addon_updater.py"
+
+
+def load_addon_updater_module():
+    sys.modules.setdefault("bpy", types.ModuleType("bpy"))
+    sys.modules.setdefault("addon_utils", types.ModuleType("addon_utils"))
+
+    module_name = "addon_updater_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, ADDON_UPDATER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class AddonUpdaterZipSourceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.addon_updater = load_addon_updater_module()
+
+    def make_updater(self, tempdir, zip_entries):
+        tempdir = Path(tempdir)
+        stage_path = tempdir / "stage"
+        staging_path = stage_path / "update_staging"
+        addon_root = tempdir / "installed" / "coa_tools2"
+        source_zip = staging_path / "source.zip"
+
+        staging_path.mkdir(parents=True)
+        addon_root.mkdir(parents=True)
+        with zipfile.ZipFile(source_zip, "w") as zf:
+            for entry in zip_entries:
+                zf.writestr(entry, "")
+
+        updater = self.addon_updater.Singleton_updater()
+        updater._addon = "coa_tools2"
+        updater._subfolder_path = "Blender/coa_tools2"
+        updater._updater_path = str(stage_path)
+        updater._addon_root = str(addon_root)
+        updater._source_zip = str(source_zip)
+        updater._json = {}
+
+        calls = {}
+
+        def fake_merge(base, merger, clean=False):
+            calls["base"] = base
+            calls["merger"] = merger
+            calls["clean"] = clean
+
+        updater.deepMergeDirectory = fake_merge
+        updater.save_updater_json = lambda: None
+        updater.reload_addon = lambda: None
+
+        return updater, calls
+
+    def test_falls_back_to_addon_folder_in_github_zip(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            updater, calls = self.make_updater(
+                tempdir,
+                [
+                    "Aodaruma-coa_tools2-1234567/coa_tools2/__init__.py",
+                    "Aodaruma-coa_tools2-1234567/coa_tools2/addon_updater.py",
+                ],
+            )
+
+            updater.unpack_staged_zip(clean=True)
+
+            self.assertEqual(
+                Path(calls["merger"]).parts[-2:],
+                ("Aodaruma-coa_tools2-1234567", "coa_tools2"),
+            )
+            self.assertTrue(calls["clean"])
+
+    def test_prefers_configured_subfolder_when_present(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            updater, calls = self.make_updater(
+                tempdir,
+                [
+                    "Aodaruma-coa_tools2-1234567/Blender/coa_tools2/__init__.py",
+                    "Aodaruma-coa_tools2-1234567/coa_tools2/__init__.py",
+                ],
+            )
+
+            updater.unpack_staged_zip()
+
+            self.assertEqual(
+                Path(calls["merger"]).parts[-2:],
+                ("Blender", "coa_tools2"),
+            )
+
+    def test_rejects_multiple_addon_folder_matches(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            updater, calls = self.make_updater(
+                tempdir,
+                [
+                    "root-a/coa_tools2/__init__.py",
+                    "root-b/coa_tools2/__init__.py",
+                ],
+            )
+
+            with self.assertRaises(ValueError):
+                updater.unpack_staged_zip()
+
+            self.assertEqual(calls, {})
+
+    def test_rejects_multiple_configured_subfolder_matches(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            updater, calls = self.make_updater(
+                tempdir,
+                [
+                    "root-a/Blender/coa_tools2/__init__.py",
+                    "root-b/Blender/coa_tools2/__init__.py",
+                ],
+            )
+
+            with self.assertRaises(ValueError):
+                updater.unpack_staged_zip()
+
+            self.assertEqual(calls, {})
+
+    def test_ignores_unsafe_relative_subfolder_candidates(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            updater, _calls = self.make_updater(
+                tempdir,
+                ["root-a/coa_tools2/__init__.py"],
+            )
+            updater._subfolder_path = "../coa_tools2"
+
+            self.assertEqual(updater._source_subfolder_candidates(), ["coa_tools2"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Resolve manual updater failures when the downloaded ZIP does not place the add-on at the updater's original expected path.

## Root Cause

The updater expected `__init__.py` either at the ZIP root or in one fixed subfolder. GitHub archive ZIPs and release ZIPs can contain different top-level folder layouts, so the updater could fail with `ValueError: __init__ file not found in new source` even when a valid `coa_tools2` add-on folder was present.

## Changes

- Resolve add-on source folders from direct ZIP roots, configured subfolders, and GitHub archive-style nested `coa_tools2` folders.
- Prefer the configured subfolder when it is uniquely present.
- Reject ambiguous ZIPs with multiple matching add-on source folders instead of selecting the first match silently.
- Ignore unsafe relative configured subfolder candidates that contain `..`.
- Add focused unit tests for GitHub ZIP layout, configured subfolder layout, ambiguous matches, and unsafe relative subfolder handling.

## Validation

- `uv run python scripts/validate_blender_addon.py`
- `uv run python -m unittest tests.test_addon_updater_zip_source`
- Blender 5.1.1 clean user directory: add-on enable/disable smoke test passed with `coa_tools2 Blender enable/disable smoke OK.`

Fixes #81
