### PR TITLE
fix: migrate old COA Tools slot data

### DIFF
--- a/coa_tools2/__init__.py
+++ b/coa_tools2/__init__.py
@@ -509,11 +509,55 @@ def check_for_deprecated_data(dummy):
             bpy.context.scene.coa_tools2.deprecated_data_found = True
 
 
+def has_old_coatools_customdata(data):
+    try:
+        return "coa_tools" in data or data.get("coa_tools") is not None
+    except (AttributeError, TypeError):
+        return False
+
+
+def data_path_has_old_coatools(data_path):
+    return bool(data_path) and (
+        "coa_tools." in data_path or '["coa_tools"]' in data_path
+    )
+
+
+def has_old_coatools_animation_data(data):
+    animation_data = getattr(data, "animation_data", None)
+    if animation_data is None:
+        return False
+
+    for driver in animation_data.drivers:
+        if data_path_has_old_coatools(driver.data_path):
+            return True
+        for variable in driver.driver.variables:
+            for target in variable.targets:
+                if data_path_has_old_coatools(target.data_path):
+                    return True
+    return False
+
+
 @persistent
 def check_for_old_coatools(dummy):
-    for obj in bpy.data.objects:
-        if "coa_tools" in obj:
+    data_blocks = []
+    data_blocks.extend(bpy.data.objects)
+    data_blocks.extend(bpy.data.meshes)
+    data_blocks.extend(bpy.data.armatures)
+    data_blocks.extend(bpy.data.scenes)
+
+    for armature_data in bpy.data.armatures:
+        data_blocks.extend(armature_data.bones)
+
+    for data in data_blocks:
+        if has_old_coatools_customdata(data) or has_old_coatools_animation_data(data):
             bpy.context.scene.coa_tools2.old_coatools_found = True
+            return
+
+    for action in bpy.data.actions:
+        for fcurve in action.fcurves:
+            if data_path_has_old_coatools(fcurve.data_path):
+                bpy.context.scene.coa_tools2.old_coatools_found = True
+                return
 
 
 @persistent

--- a/coa_tools2/functions.py
+++ b/coa_tools2/functions.py
@@ -811,11 +811,28 @@ def set_view(scene, mode):
                                     relative=False,
                                 )
                             else:
-                                bpy.ops.view3d.view_axis(
-                                    type="FRONT",
-                                    align_active=False,
-                                    relative=False,
+                                region = next(
+                                    (
+                                        region
+                                        for region in area.regions
+                                        if region.type == "WINDOW"
+                                    ),
+                                    None,
                                 )
+                                if region is None:
+                                    continue
+                                with bpy.context.temp_override(
+                                    screen=screen,
+                                    area=area,
+                                    region=region,
+                                    space_data=active_space_data,
+                                ):
+                                    if bpy.ops.view3d.view_axis.poll():
+                                        bpy.ops.view3d.view_axis(
+                                            type="FRONT",
+                                            align_active=False,
+                                            relative=False,
+                                        )
 
     elif mode == "3D":
         for screen in bpy.data.screens:
@@ -1028,6 +1045,36 @@ def get_clamped_slot_index(obj, obj_eval=None):
     return max(0, min(index, len(obj.coa_tools2.slot) - 1))
 
 
+def set_object_mesh_data_preserve_vertex_groups(obj, mesh):
+    if obj is None or mesh is None or obj.data == mesh:
+        return
+
+    vertex_groups = [
+        (group.name, getattr(group, "lock_weight", False)) for group in obj.vertex_groups
+    ]
+    active_group_name = None
+    try:
+        active_group = obj.vertex_groups.active
+        active_group_name = active_group.name if active_group is not None else None
+    except AttributeError:
+        pass
+
+    obj.data = mesh
+
+    for name, lock_weight in vertex_groups:
+        if name in obj.vertex_groups:
+            group = obj.vertex_groups[name]
+        else:
+            group = obj.vertex_groups.new(name=name)
+        try:
+            group.lock_weight = lock_weight
+        except AttributeError:
+            pass
+
+    if active_group_name in obj.vertex_groups:
+        obj.vertex_groups.active_index = obj.vertex_groups[active_group_name].index
+
+
 def change_slot_mesh_data(
     context,
     obj,
@@ -1055,7 +1102,7 @@ def change_slot_mesh_data(
 
     obj = slot.id_data
     if obj.data != slot.mesh:
-        obj.data = slot.mesh
+        set_object_mesh_data_preserve_vertex_groups(obj, slot.mesh)
     set_alpha(obj, context, obj.coa_tools2.alpha if alpha is None else alpha)
     if modulate_color is not None:
         set_modulate_color(obj, context, modulate_color)
@@ -1063,17 +1110,9 @@ def change_slot_mesh_data(
     if sync_active:
         for slot2 in obj.coa_tools2.slot:
             if slot != slot2 and slot2.active:
-                object.__setattr__(slot2, "_lock_active_update", True)
-                try:
-                    slot2.active = False
-                finally:
-                    object.__setattr__(slot2, "_lock_active_update", False)
+                slot2["active"] = False
             elif slot == slot2 and not slot2.active:
-                object.__setattr__(slot2, "_lock_active_update", True)
-                try:
-                    slot2.active = True
-                finally:
-                    object.__setattr__(slot2, "_lock_active_update", False)
+                slot2["active"] = True
 
     if "coa_base_sprite" in obj.modifiers:
         hide_base_sprite = bool(slot.mesh.coa_tools2.hide_base_sprite)

--- a/coa_tools2/operators/convert_from_old.py
+++ b/coa_tools2/operators/convert_from_old.py
@@ -27,6 +27,7 @@ import mathutils
 from mathutils import Vector, Matrix, Quaternion
 import math
 import bmesh
+import re
 from bpy.props import (
     FloatProperty,
     IntProperty,
@@ -40,6 +41,14 @@ from bpy.props import (
 )
 import os
 from bpy_extras.io_utils import ExportHelper, ImportHelper
+from .. import functions
+
+
+def get_blender_collection(data, name):
+    try:
+        return getattr(bpy.data, name)
+    except AttributeError:
+        return None
 
 
 class COATOOLS2_OT_ConvertOldVersionCoatools(bpy.types.Operator):
@@ -48,46 +57,339 @@ class COATOOLS2_OT_ConvertOldVersionCoatools(bpy.types.Operator):
     bl_description = "convert all sprites from old version COA Tools (by ndee85)"
     bl_options = {"REGISTER", "UNDO"}
 
-    def change_customdata_name(self, context, obj):
-        # change custom property's name "coa_tools" to "coa_tools2"
-        if "coa_tools" in obj or obj.get("coa_tools") is not None:
-            obj["coa_tools2"] = obj["coa_tools"]
-            # obj["coa_tools"]
-            del obj["coa_tools"]
+    OLD_PROP_NAME = "coa_tools"
+    NEW_PROP_NAME = "coa_tools2"
 
-        else:
-            print("coa_tools not found in " + obj.name, type(obj))
+    def has_id_customdata(self, data):
+        try:
+            return self.OLD_PROP_NAME in data or data.get(self.OLD_PROP_NAME) is not None
+        except (AttributeError, TypeError):
+            return False
+
+    def has_rna_customdata(self, data):
+        return hasattr(data, self.OLD_PROP_NAME) and hasattr(data, self.NEW_PROP_NAME)
+
+    def has_customdata(self, data):
+        return self.has_id_customdata(data) or self.has_rna_customdata(data)
+
+    def get_enum_value(self, prop, value):
+        if isinstance(value, str):
+            return value
+
+        try:
+            index = int(value)
+        except (TypeError, ValueError):
+            return value
+
+        enum_items = list(prop.enum_items)
+        if 0 <= index < len(enum_items):
+            return enum_items[index].identifier
+        for item in enum_items:
+            if item.value == index:
+                return item.identifier
+        return value
+
+    def get_pointer_value(self, prop, value):
+        if value is None or hasattr(value, "name"):
+            return value
+
+        fixed_type = getattr(prop, "fixed_type", None)
+        if fixed_type is None or not isinstance(value, str):
+            return value
+
+        collection_name_by_type = {
+            "Mesh": "meshes",
+            "Object": "objects",
+            "Material": "materials",
+            "Image": "images",
+            "Armature": "armatures",
+            "Action": "actions",
+        }
+        collection = get_blender_collection(
+            bpy.data, collection_name_by_type.get(fixed_type.identifier, "")
+        )
+        if collection is not None:
+            pointer = collection.get(value)
+            if pointer is not None:
+                return pointer
+        return value
+
+    def get_property_value(self, prop, value):
+        if prop.type == "ENUM":
+            return self.get_enum_value(prop, value)
+        if prop.type == "POINTER":
+            return self.get_pointer_value(prop, value)
+        return value
+
+    def set_property_value(self, dst, key, prop, value):
+        value = self.get_property_value(prop, value)
+
+        if prop.type in {"ENUM", "POINTER"}:
+            try:
+                setattr(dst, key, value)
+                return
+            except (AttributeError, TypeError, ValueError):
+                pass
+
+        try:
+            dst[key] = value
+        except (AttributeError, TypeError, ValueError):
+            try:
+                setattr(dst, key, value)
+            except (AttributeError, TypeError, ValueError):
+                pass
+
+    def copy_mapping_to_property_group(self, src, dst):
+        for key in src.keys():
+            prop = dst.bl_rna.properties.get(key)
+            if prop is None:
+                try:
+                    dst[key] = src[key]
+                except (AttributeError, TypeError, ValueError):
+                    pass
+                continue
+
+            value = src[key]
+            if prop.type == "COLLECTION":
+                dst_collection = getattr(dst, key)
+                try:
+                    dst_collection.clear()
+                except AttributeError:
+                    while len(dst_collection) > 0:
+                        dst_collection.remove(0)
+                for src_item in value:
+                    dst_item = dst_collection.add()
+                    object.__setattr__(dst_item, "_lock_active_update", True)
+                    try:
+                        self.copy_mapping_to_property_group(src_item, dst_item)
+                    finally:
+                        object.__setattr__(dst_item, "_lock_active_update", False)
+            elif prop.is_readonly:
+                try:
+                    dst[key] = value
+                except (AttributeError, TypeError, ValueError):
+                    pass
+            else:
+                self.set_property_value(dst, key, prop, value)
+
+    def copy_property_group(self, src, dst):
+        for prop in src.bl_rna.properties:
+            name = prop.identifier
+            if name == "rna_type":
+                continue
+
+            try:
+                value = getattr(src, name)
+            except (AttributeError, TypeError):
+                continue
+
+            if prop.type == "COLLECTION":
+                dst_collection = getattr(dst, name)
+                try:
+                    dst_collection.clear()
+                except AttributeError:
+                    while len(dst_collection) > 0:
+                        dst_collection.remove(0)
+                for src_item in value:
+                    dst_item = dst_collection.add()
+                    object.__setattr__(dst_item, "_lock_active_update", True)
+                    try:
+                        self.copy_property_group(src_item, dst_item)
+                    finally:
+                        object.__setattr__(dst_item, "_lock_active_update", False)
+            elif prop.is_readonly:
+                continue
+            else:
+                self.set_property_value(dst, name, prop, value)
+
+        for key in getattr(src, "keys", lambda: [])():
+            if dst.bl_rna.properties.get(key) is not None:
+                continue
+            try:
+                dst[key] = src[key]
+            except (AttributeError, TypeError, ValueError):
+                pass
+
+    def change_customdata_name(self, context, data):
+        # Change custom property's name from "coa_tools" to "coa_tools2".
+        if self.has_id_customdata(data):
+            if hasattr(data, self.NEW_PROP_NAME):
+                self.copy_mapping_to_property_group(
+                    data[self.OLD_PROP_NAME],
+                    getattr(data, self.NEW_PROP_NAME),
+                )
+            else:
+                data[self.NEW_PROP_NAME] = data[self.OLD_PROP_NAME]
+            del data[self.OLD_PROP_NAME]
+            return True
+
+        if self.has_rna_customdata(data):
+            self.copy_property_group(
+                getattr(data, self.OLD_PROP_NAME),
+                getattr(data, self.NEW_PROP_NAME),
+            )
+            return True
+
+        return False
+
+    def get_slot_meshes(self, obj):
+        meshes = []
+        if obj.type != "MESH":
+            return meshes
+
+        try:
+            if obj.coa_tools2.type != "SLOT":
+                return meshes
+
+            for slot in obj.coa_tools2.slot:
+                if slot.mesh is not None and slot.mesh not in meshes:
+                    meshes.append(slot.mesh)
+        except (AttributeError, TypeError):
+            pass
+        return meshes
+
+    def collect_meshes_referenced_by_objects(self):
+        meshes = []
+        for obj in bpy.data.objects:
+            if obj.type != "MESH":
+                continue
+            if obj.data is not None and obj.data not in meshes:
+                meshes.append(obj.data)
+            for mesh in self.get_slot_meshes(obj):
+                if mesh not in meshes:
+                    meshes.append(mesh)
+        return meshes
+
+    def normalize_slot_objects(self):
+        for obj in bpy.data.objects:
+            if obj.type != "MESH":
+                continue
+            try:
+                if obj.coa_tools2.type != "SLOT" or len(obj.coa_tools2.slot) == 0:
+                    continue
+            except (AttributeError, TypeError):
+                continue
+
+            slot_count = len(obj.coa_tools2.slot)
+            slot_index = max(0, min(int(obj.coa_tools2.slot_index), slot_count - 1))
+
+            object.__setattr__(obj.coa_tools2, "_lock_slot_index_update", True)
+            try:
+                obj.coa_tools2.slot_index = slot_index
+                obj.coa_tools2.slot_reset_index = max(
+                    0, min(int(obj.coa_tools2.slot_reset_index), slot_count - 1)
+                )
+            finally:
+                object.__setattr__(obj.coa_tools2, "_lock_slot_index_update", False)
+
+            for i, slot in enumerate(obj.coa_tools2.slot):
+                slot.index = i
+                slot["active"] = i == slot_index
+
+            active_mesh = obj.coa_tools2.slot[slot_index].mesh
+            if active_mesh is not None:
+                functions.set_object_mesh_data_preserve_vertex_groups(obj, active_mesh)
+
+    def normalize_edit_state(self):
+        for obj in bpy.data.objects:
+            try:
+                obj.coa_tools2["edit_mesh"] = False
+                obj.coa_tools2["edit_armature"] = False
+                obj.coa_tools2["edit_weights"] = False
+                obj.coa_tools2["edit_shapekey"] = False
+                obj.coa_tools2["edit_mode"] = "OBJECT"
+            except (AttributeError, TypeError):
+                pass
+
+    def iter_action_fcurves(self, action):
+        legacy_fcurves = getattr(action, "fcurves", None)
+        if legacy_fcurves is not None:
+            yield from legacy_fcurves
+            return
+
+        action_slots = list(getattr(action, "slots", []))
+        for layer in getattr(action, "layers", []):
+            for strip in getattr(layer, "strips", []):
+                for action_slot in action_slots:
+                    try:
+                        channelbag = strip.channelbag(action_slot)
+                    except Exception:
+                        continue
+                    if channelbag is not None:
+                        yield from getattr(channelbag, "fcurves", [])
+
+    def convert_animation_data_paths(self):
+        for action in bpy.data.actions:
+            for fcurve in self.iter_action_fcurves(action):
+                fcurve.data_path = self.convert_data_path(fcurve.data_path)
+
+        animated_data = []
+        animated_data.extend(bpy.data.objects)
+        animated_data.extend(bpy.data.meshes)
+        animated_data.extend(bpy.data.armatures)
+        animated_data.extend(bpy.data.scenes)
+
+        for data in animated_data:
+            if data.animation_data is None:
+                continue
+            for driver in data.animation_data.drivers:
+                driver.data_path = self.convert_data_path(driver.data_path)
+                for variable in driver.driver.variables:
+                    for target in variable.targets:
+                        if target.data_path:
+                            target.data_path = self.convert_data_path(target.data_path)
+
+    def convert_data_path(self, data_path):
+        if not data_path:
+            return data_path
+        data_path = re.sub(
+            r'\["coa_tools"\]\["([^"]+)"\]',
+            r"coa_tools2.\1",
+            data_path,
+        )
+        return data_path.replace("coa_tools.", "coa_tools2.").replace(
+            '["coa_tools"]', "coa_tools2"
+        )
+
+    def convert_bones(self):
+        converted = 0
+        for armature_data in bpy.data.armatures:
+            for bone in armature_data.bones:
+                if self.change_customdata_name(bpy.context, bone):
+                    converted += 1
+        return converted
 
     def execute(self, context):
-        # convert objects
-        objects = []
+        converted_objects = 0
         for obj in bpy.data.objects:
-            # print(obj.name, obj.type, dir(obj), obj.get("coa_tools"))
-            if obj.get("coa_tools") is not None:
-                objects.append(obj)
+            if self.change_customdata_name(context, obj):
+                converted_objects += 1
 
-        if len(objects) > 0:
-            # search sprite in each armature and convert to new version
-            for obj in objects:
-                if obj.type == "ARMATURE":
-                    for child in obj.children:
-                        if child.type == "MESH":
-                            # convert object
-                            self.change_customdata_name(context, child)
+        converted_meshes = 0
+        meshes = list(bpy.data.meshes)
+        for mesh in self.collect_meshes_referenced_by_objects():
+            if mesh not in meshes:
+                meshes.append(mesh)
+        for mesh in meshes:
+            if self.change_customdata_name(context, mesh):
+                converted_meshes += 1
 
-                            # convert mesh of object
-                            self.change_customdata_name(context, child.data)
+        converted_scenes = 0
+        for scene in bpy.data.scenes:
+            if self.change_customdata_name(context, scene):
+                converted_scenes += 1
 
-                # convert armature
-                self.change_customdata_name(context, obj)
-
-        if "coa_tools" in context.scene:
-            context.scene["coa_tools2"] = context.scene["coa_tools"]
-            del context.scene["coa_tools"]
+        converted_bones = self.convert_bones()
+        self.convert_animation_data_paths()
+        self.normalize_slot_objects()
+        self.normalize_edit_state()
 
         # finish
         self.report(
-            {"INFO"}, "Convert All sprites from old version COA Tools is finished."
+            {"INFO"},
+            "Convert old COA Tools data finished. "
+            f"Objects: {converted_objects}, meshes: {converted_meshes}, "
+            f"bones: {converted_bones}, scenes: {converted_scenes}.",
         )
         context.scene.coa_tools2.old_coatools_found = False
         return {"FINISHED"}

--- a/coa_tools2/operators/slot_handling.py
+++ b/coa_tools2/operators/slot_handling.py
@@ -195,12 +195,8 @@ class COATOOLS2_OT_CreateSlotObject(bpy.types.Operator):
                             # item.name = slot.name
                             item.mesh = slot.mesh
                     if item != None:
-                        object.__setattr__(item, "_lock_active_update", True)
-                        try:
-                            item.active = False
-                        finally:
-                            object.__setattr__(item, "_lock_active_update", False)
-        obj.coa_tools2.slot[0].active = True
+                        item["active"] = False
+        obj.coa_tools2.slot[0]["active"] = True
         ### delete original sprite
         for sprite in objs:
             bpy.data.objects.remove(sprite, do_unlink=True)
@@ -268,7 +264,7 @@ class COATOOLS2_OT_RemoveFromSlot(bpy.types.Operator):
         for i, s in enumerate(obj.coa_tools2.slot):
             s["index"] = i
         if len(obj.coa_tools2.slot) > 0:
-            obj.coa_tools2.slot[active_idx].active = True
+            obj.coa_tools2.slot[active_idx]["active"] = True
         else:
             bpy.data.objects.remove(obj, do_unlink=True)
 

--- a/coa_tools2/properties.py
+++ b/coa_tools2/properties.py
@@ -348,17 +348,13 @@ class SlotData(bpy.types.PropertyGroup):
         object.__setattr__(self, "_lock_active_update", True)
         try:
             if not self.active:
-                self.active = True
+                self["active"] = True
 
             obj.coa_tools2.slot_index = self.index
             functions.hide_base_sprite(obj)
             for slot in obj.coa_tools2.slot:
                 if slot != self and slot.active:
-                    object.__setattr__(slot, "_lock_active_update", True)
-                    try:
-                        slot.active = False
-                    finally:
-                        object.__setattr__(slot, "_lock_active_update", False)
+                    slot["active"] = False
         finally:
             object.__setattr__(self, "_lock_active_update", False)
 

--- a/scripts/validate_old_coatools_conversion.py
+++ b/scripts/validate_old_coatools_conversion.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Blender validation for old COA Tools data migration."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import bpy
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def reset_scene() -> None:
+    bpy.ops.object.mode_set(mode="OBJECT") if bpy.ops.object.mode_set.poll() else None
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete()
+    for mesh in list(bpy.data.meshes):
+        bpy.data.meshes.remove(mesh)
+    for action in list(bpy.data.actions):
+        bpy.data.actions.remove(action)
+
+
+def register_addon():
+    sys.path.insert(0, str(ROOT))
+    addon = importlib.import_module("coa_tools2")
+    addon.register()
+    return addon
+
+
+def unregister_addon(addon) -> None:
+    try:
+        addon.unregister()
+    except Exception:
+        pass
+
+
+def iter_action_fcurves(action):
+    legacy_fcurves = getattr(action, "fcurves", None)
+    if legacy_fcurves is not None:
+        yield from legacy_fcurves
+        return
+
+    action_slots = list(getattr(action, "slots", []))
+    for layer in getattr(action, "layers", []):
+        for strip in getattr(layer, "strips", []):
+            for action_slot in action_slots:
+                try:
+                    channelbag = strip.channelbag(action_slot)
+                except Exception:
+                    continue
+                if channelbag is not None:
+                    yield from getattr(channelbag, "fcurves", [])
+
+
+def make_mesh(name: str, x_offset: float) -> bpy.types.Mesh:
+    mesh = bpy.data.meshes.new(name)
+    verts = [
+        (x_offset - 0.5, 0.0, -0.5),
+        (x_offset + 0.5, 0.0, -0.5),
+        (x_offset + 0.5, 0.0, 0.5),
+        (x_offset - 0.5, 0.0, 0.5),
+    ]
+    mesh.from_pydata(verts, [], [(0, 1, 2, 3)])
+    mesh.update()
+    return mesh
+
+
+def build_old_scene(addon):
+    bpy.ops.object.armature_add()
+    armature = bpy.context.object
+    armature.name = "SpriteArmature"
+    armature["coa_tools"] = {
+        "sprite_object": True,
+        "show_children": True,
+    }
+    armature.data.bones[0]["coa_tools"] = {"favorite": True}
+
+    mesh_a = make_mesh("Slot_A", 0.0)
+    mesh_b = make_mesh("Slot_B", 1.0)
+    mesh_a["coa_tools"] = {"hide_base_sprite": True}
+    mesh_b["coa_tools"] = {"hide_base_sprite": False}
+
+    slot_obj = bpy.data.objects.new("SlotSprite", mesh_a)
+    bpy.context.collection.objects.link(slot_obj)
+    slot_obj.parent = armature
+    slot_obj["coa_tools"] = {
+        "type": 2,
+        "slot_index": 1,
+        "slot_reset_index": 1,
+        "slot_show": True,
+        "alpha": 0.5,
+        "edit_mesh": True,
+        "edit_armature": True,
+        "edit_weights": True,
+        "edit_shapekey": True,
+        "edit_mode": 3,
+        "slot": [
+            {"mesh": "Slot_A", "name": "Slot_A", "index": 0, "active": False},
+            {"mesh": "Slot_B", "name": "Slot_B", "index": 1, "active": True},
+        ],
+    }
+
+    slot_obj.vertex_groups.new(name="Bone")
+    slot_obj.vertex_groups.new(name="coa_base_sprite")
+    modifier = slot_obj.modifiers.new("Armature", "ARMATURE")
+    modifier.object = armature
+
+    bpy.context.scene["coa_tools"] = {"view": 1}
+    slot_obj.keyframe_insert(data_path='["coa_tools"]["slot_index"]', frame=1)
+    driver = slot_obj.driver_add('["coa_tools"]["alpha"]').driver
+    driver.expression = "0.75"
+
+    return armature, slot_obj, mesh_a, mesh_b
+
+
+def assert_no_old_data(armature, slot_obj, mesh_a, mesh_b) -> None:
+    assert "coa_tools" not in armature
+    assert "coa_tools" not in slot_obj
+    assert "coa_tools" not in mesh_a
+    assert "coa_tools" not in mesh_b
+    assert "coa_tools" not in bpy.context.scene
+    assert "coa_tools" not in armature.data.bones[0]
+
+
+def validate_conversion(armature, slot_obj, mesh_a, mesh_b) -> None:
+    assert slot_obj.parent == armature
+    assert slot_obj.coa_tools2.type == "SLOT"
+    assert len(slot_obj.coa_tools2.slot) == 2
+    assert slot_obj.coa_tools2.slot_index == 1
+    assert slot_obj.coa_tools2.slot_reset_index == 1
+    assert slot_obj.coa_tools2.slot[0].mesh == mesh_a
+    assert slot_obj.coa_tools2.slot[1].mesh == mesh_b
+    assert not slot_obj.coa_tools2.slot[0].active
+    assert slot_obj.coa_tools2.slot[1].active
+    assert slot_obj.data == mesh_b
+    assert slot_obj.modifiers["Armature"].object == armature
+    assert "Bone" in slot_obj.vertex_groups
+    assert "coa_base_sprite" in slot_obj.vertex_groups
+
+    assert mesh_a.coa_tools2.hide_base_sprite
+    assert not mesh_b.coa_tools2.hide_base_sprite
+    assert armature.coa_tools2.show_children
+    assert "sprite_object" in armature.coa_tools2
+    assert armature.data.bones[0].coa_tools2.favorite
+    assert bpy.context.scene.coa_tools2.view == "2D"
+
+    for action in bpy.data.actions:
+        for fcurve in iter_action_fcurves(action):
+            assert "coa_tools." not in fcurve.data_path
+            assert "coa_tools2." in fcurve.data_path
+
+    for fcurve in slot_obj.animation_data.drivers:
+        assert "coa_tools." not in fcurve.data_path
+        assert "coa_tools2." in fcurve.data_path
+
+    slot_obj.coa_tools2.slot_index = 0
+    addon = sys.modules["coa_tools2"]
+    addon.functions.change_slot_mesh_data(bpy.context, slot_obj)
+    assert slot_obj.data == mesh_a
+    assert slot_obj.parent == armature
+    assert slot_obj.modifiers["Armature"].object == armature
+    assert "coa_base_sprite" in slot_obj.vertex_groups
+
+    bpy.context.view_layer.objects.active = slot_obj
+    slot_obj.select_set(True)
+    bpy.ops.object.mode_set(mode="EDIT")
+    import bmesh
+
+    bm = bmesh.from_edit_mesh(slot_obj.data)
+    assert len(bm.verts) > 0
+    bpy.ops.object.mode_set(mode="OBJECT")
+
+
+def main() -> int:
+    reset_scene()
+    addon = register_addon()
+    try:
+        armature, slot_obj, mesh_a, mesh_b = build_old_scene(addon)
+
+        addon.check_for_old_coatools(None)
+        assert bpy.context.scene.coa_tools2.old_coatools_found
+
+        result = bpy.ops.coa_tools2.convert_old_version_coatools()
+        assert result == {"FINISHED"}
+        validate_conversion(armature, slot_obj, mesh_a, mesh_b)
+        assert_no_old_data(armature, slot_obj, mesh_a, mesh_b)
+        print("Old COA Tools conversion validation OK.")
+        return 0
+    finally:
+        unregister_addon(addon)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Convert old COA Tools custom data across objects, meshes, scenes, armature bones, and animation data paths.
- Preserve slot mesh references, active slot state, parent/modifier/vertex group data, and inactive slot mesh metadata during conversion.
- Preserve vertex group definitions when switching slot mesh data in Blender 5.1.
- Add a Blender 5.1 background validation script that builds old-format raw custom data and verifies the conversion end to end.

## Root Cause
The old converter only handled a narrow subset of scene object data. Slot mesh datablocks, scene/bone metadata, and animation paths could remain in old `coa_tools` storage, and Blender 5.1 clears object vertex groups when `obj.data` is replaced with another mesh.

## Validation
- `uv run python scripts\validate_blender_addon.py`
- `git diff --check`
- `Blender 5.1.1 --background --factory-startup --python scripts\validate_old_coatools_conversion.py`

Fixes #52