### PR TITLE
fix: refresh Automesh dependency state after install

### DIFF
--- a/coa_tools2/__init__.py
+++ b/coa_tools2/__init__.py
@@ -172,6 +172,18 @@ class COATools2Preferences(bpy.types.AddonPreferences):
             icon="IMPORT",
             text="Install numpy / opencv",
         )
+        install_state = install_dependencies.get_install_state()
+        if install_state is not None and (
+            install_state["running"] or install_state["done"]
+        ):
+            status_icon = "CHECKMARK" if install_state["success"] else "INFO"
+            if install_state["done"] and not install_state["success"]:
+                status_icon = "ERROR"
+            box.label(
+                text=f"Install progress: {int(install_state['progress'])}%",
+                icon=status_icon,
+            )
+            box.label(text=install_state["status_message"])
         if not deps_ok:
             box.label(
                 text="After install, restart Blender or re-enable addon.", icon="INFO"

--- a/coa_tools2/dependency_manager.py
+++ b/coa_tools2/dependency_manager.py
@@ -30,23 +30,32 @@ def dependencies_installed():
     return all(state.values())
 
 
-def _try_import(module_name):
+def import_optional_module(module_name):
+    ensure_vendor_path()
+    importlib.invalidate_caches()
     try:
-        importlib.import_module(module_name)
-        return True, ""
+        return importlib.import_module(module_name), ""
     except Exception as exc:
-        return False, f"{type(exc).__name__}: {exc}"
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def import_required_modules():
+    modules = {}
+    errors = {}
+    for module_name in REQUIRED_MODULES:
+        module, error = import_optional_module(module_name)
+        if module is None:
+            errors[module_name] = error
+        else:
+            modules[module_name] = module
+    return modules, errors
 
 
 def dependency_state_with_errors():
-    ensure_vendor_path()
+    modules, errors = import_required_modules()
     state = {}
-    errors = {}
     for module_name in REQUIRED_MODULES:
-        is_ok, error = _try_import(module_name)
-        state[module_name] = is_ok
-        if not is_ok:
-            errors[module_name] = error
+        state[module_name] = module_name in modules
     return state, errors
 
 

--- a/coa_tools2/operators/automesh.py
+++ b/coa_tools2/operators/automesh.py
@@ -23,17 +23,20 @@ from math import radians, degrees
 import pdb
 from typing import Optional
 
-try:
-    import cv2
-except Exception:
-    cv2 = None
-
-try:
-    import numpy as np
-except Exception:
-    np = None
+cv2 = None
+np = None
 
 # ======================================================================================================================
+
+
+def refresh_dependencies():
+    global cv2
+    global np
+
+    modules, errors = dependency_manager.import_required_modules()
+    cv2 = modules.get("cv2")
+    np = modules.get("numpy")
+    return cv2 is not None and np is not None, errors
 
 
 def has_interactive_ui(context):
@@ -86,7 +89,8 @@ def get_contour(
     padding: Optional[int] = 50,
 ):
     """Get the contour points of image"""
-    if cv2 is None or np is None:
+    deps_ok, _errors = refresh_dependencies()
+    if not deps_ok:
         return [], []
 
     # get image with alpha
@@ -336,8 +340,8 @@ class COATOOLS2_OT_AutomeshFromTexture(bpy.types.Operator):
         )
 
     def execute(self, context):
-        if cv2 is None or np is None:
-            _, dep_errors = dependency_manager.dependency_state_with_errors()
+        deps_ok, dep_errors = refresh_dependencies()
+        if not deps_ok:
             if dep_errors:
                 print("COA Tools2 automesh dependency import errors:")
                 for module_name, error in dep_errors.items():

--- a/coa_tools2/operators/install_dependencies.py
+++ b/coa_tools2/operators/install_dependencies.py
@@ -3,6 +3,8 @@ import threading
 
 from .. import dependency_manager
 
+_INSTALL_STATE = None
+
 
 def _has_modal_ui(context):
     return (
@@ -18,9 +20,23 @@ def _new_install_state():
         "done": False,
         "success": False,
         "logs": [],
-        "progress": 0.0,
-        "status_message": "Starting dependency installation...",
+        "progress": 1.0,
+        "status_message": "Preparing dependency installation...",
     }
+
+
+def get_install_state():
+    if _INSTALL_STATE is None:
+        return None
+
+    state = {
+        "done": bool(_INSTALL_STATE["done"]),
+        "success": bool(_INSTALL_STATE["success"]),
+        "progress": float(_INSTALL_STATE["progress"]),
+        "status_message": str(_INSTALL_STATE["status_message"]),
+        "running": COATOOLS2_OT_InstallPythonDependencies._is_running,
+    }
+    return state
 
 
 def _make_progress_callback(state):
@@ -84,6 +100,11 @@ class COATOOLS2_OT_InstallPythonDependencies(bpy.types.Operator):
 
         state["success"] = success
         state["logs"] = logs
+        if success:
+            state["progress"] = 100.0
+            state["status_message"] = "Installation completed."
+        else:
+            state["status_message"] = "Installation failed."
         state["done"] = True
 
     def _finish_install(self, success, logs):
@@ -102,7 +123,9 @@ class COATOOLS2_OT_InstallPythonDependencies(bpy.types.Operator):
         return {"CANCELLED"}
 
     def _run_sync(self):
+        global _INSTALL_STATE
         state = _new_install_state()
+        _INSTALL_STATE = state
         try:
             success, logs = dependency_manager.install_dependencies(
                 progress_callback=_make_progress_callback(state)
@@ -110,12 +133,19 @@ class COATOOLS2_OT_InstallPythonDependencies(bpy.types.Operator):
         except Exception as exc:
             success = False
             logs = _exception_log(exc)
+            state["status_message"] = "Installation failed."
+        state["success"] = success
+        state["logs"] = logs
+        state["progress"] = 100.0 if success else state["progress"]
+        state["done"] = True
         return self._finish_install(success, logs)
 
     def _start_modal(self, context):
+        global _INSTALL_STATE
         COATOOLS2_OT_InstallPythonDependencies._is_running = True
         state = _new_install_state()
         self._install_state = state
+        _INSTALL_STATE = state
 
         wm = context.window_manager
         wm.progress_begin(0, 100)
@@ -127,6 +157,10 @@ class COATOOLS2_OT_InstallPythonDependencies(bpy.types.Operator):
         )
         self._thread.start()
 
+        self.report(
+            {"INFO"},
+            "Installing numpy/opencv. Progress is shown in Preferences.",
+        )
         return {"RUNNING_MODAL"}
 
     def invoke(self, context, event):
@@ -135,8 +169,7 @@ class COATOOLS2_OT_InstallPythonDependencies(bpy.types.Operator):
             return {"CANCELLED"}
         if not _has_modal_ui(context):
             return self._run_sync()
-        self._start_modal(context)
-        return context.window_manager.invoke_popup(self, width=460)
+        return self._start_modal(context)
 
     def execute(self, context):
         if COATOOLS2_OT_InstallPythonDependencies._is_running:

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -1,0 +1,69 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "coa_tools2" / "dependency_manager.py"
+
+
+def load_dependency_manager():
+    spec = importlib.util.spec_from_file_location(
+        "dependency_manager_under_test", MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DependencyManagerTests(unittest.TestCase):
+    def test_dependency_state_checks_new_vendor_modules_after_initial_miss(self):
+        manager = load_dependency_manager()
+        manager.REQUIRED_MODULES = (
+            "fake_numpy_for_coa_tools2",
+            "fake_cv2_for_coa_tools2",
+        )
+        original_modules = {
+            name: sys.modules.get(name) for name in manager.REQUIRED_MODULES
+        }
+        try:
+            for name in manager.REQUIRED_MODULES:
+                sys.modules.pop(name, None)
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                vendor_path = Path(tmpdir)
+                manager.get_vendor_path = lambda: str(vendor_path)
+
+                state, errors = manager.dependency_state_with_errors()
+                self.assertFalse(state["fake_cv2_for_coa_tools2"])
+                self.assertIn("fake_cv2_for_coa_tools2", errors)
+
+                (vendor_path / "fake_cv2_for_coa_tools2.py").write_text(
+                    "VALUE = 'cv2'\n", encoding="utf-8"
+                )
+                (vendor_path / "fake_numpy_for_coa_tools2.py").write_text(
+                    "VALUE = 'numpy'\n", encoding="utf-8"
+                )
+
+                state, errors = manager.dependency_state_with_errors()
+
+                self.assertEqual(
+                    {
+                        "fake_numpy_for_coa_tools2": True,
+                        "fake_cv2_for_coa_tools2": True,
+                    },
+                    state,
+                )
+                self.assertEqual({}, errors)
+        finally:
+            for name in manager.REQUIRED_MODULES:
+                sys.modules.pop(name, None)
+                original = original_modules[name]
+                if original is not None:
+                    sys.modules[name] = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Refresh Automesh dependency imports at execution time instead of keeping stale module globals from add-on startup.
- Expose dependency install progress in the add-on Preferences panel instead of relying on a popup that can stay visually stuck at 0%.
- Add dependency-manager coverage for modules that become importable after an initial miss.

## Root Cause
Automesh imported `numpy` and `cv2` once when the add-on module loaded. If `cv2` was missing at startup and then installed in the same Blender session, Preferences correctly reported it as importable, but Automesh still used the stale `cv2 = None` module global and rejected the operation.

The installer also displayed progress through a popup path that does not reliably redraw while the worker thread is running, so the visible progress could remain at 0% even when pip was running.

## Validation
- `uv run python scripts\validate_blender_addon.py`
- `uv run python -m unittest tests.test_dependency_manager`
- `git diff --check`
- Blender 5.1.1 clean user path: confirmed `cv2` is missing before install, `bpy.ops.coa_tools2.install_python_dependencies()` finishes successfully, `dependency_manager` reports `cv2=True`, and `automesh.refresh_dependencies()` updates the same-session Automesh globals to `True`.
- Blender 5.1.1 clean user path: after installing dependencies in the same session, `bpy.ops.coa_tools2.automesh_from_texture()` reaches the normal missing-texture validation instead of dependency rejection.
