### PR TITLE
fix: make direct edit redirect opt-in

### DIFF
--- a/coa_tools2/__init__.py
+++ b/coa_tools2/__init__.py
@@ -143,10 +143,16 @@ class COATools2Preferences(bpy.types.AddonPreferences):
         description="Import/Export scale factor, 1 px = X units",
         default=0.01,
     )
+    redirect_direct_edit_mode: bpy.props.BoolProperty(
+        name="Redirect Direct Edit Mode",
+        description="Automatically switch COA sprite meshes from Blender Edit Mode to COA Tools2 Edit Mesh",
+        default=False,
+    )
 
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "sprite_import_export_scale")
+        layout.prop(self, "redirect_direct_edit_mode")
 
         deps_state, deps_errors = dependency_manager.dependency_state_with_errors()
         deps_ok = all(deps_state.values())
@@ -313,6 +319,9 @@ def _get_parent_sprite_object(obj):
 
 def _is_direct_edit_redirect_candidate(context, obj):
     wm = context.window_manager if context is not None else None
+    if not getattr(get_addon_prefs(context), "redirect_direct_edit_mode", False):
+        return False
+
     if (
         wm is None
         or bool(wm.get("coa_tools2_edit_mesh_modal_running", False))

--- a/coa_tools2/functions.py
+++ b/coa_tools2/functions.py
@@ -485,6 +485,7 @@ def get_local_dimension(obj):
 class _FallbackAddonPrefs:
     # Safe defaults used when addon preferences are temporarily unavailable.
     sprite_import_export_scale = 0.01
+    redirect_direct_edit_mode = False
     sprite_thumb_size = 64
     dragon_bones_export = False
 


### PR DESCRIPTION
## Summary
- Add a COA Tools2 preference for direct Blender Edit Mode redirection.
- Keep the new preference disabled by default so Blender Edit Mode remains unchanged unless users opt in.
- Add the same default to fallback preferences used before addon preferences are available.

## Validation
- `uv run python scripts\validate_blender_addon.py`
- `git diff --check`
- Blender 5.1.1 background validation with a clean user profile: default candidate check is disabled, and enabling the preference allows direct edit redirection.
