### PR TITLE
fix(dragonbones export): multiple fixes and improvements

### DIFF
--- a/coa_tools2/__init__.py
+++ b/coa_tools2/__init__.py
@@ -261,6 +261,7 @@ classes = (
     animation_handling.COATOOLS2_OT_RemoveEvent,
     animation_handling.COATOOLS2_OT_AddTimelineEvent,
     animation_handling.COATOOLS2_OT_RemoveTimelineEvent,
+    animation_handling.COATOOLS2_OT_RenameSpriteObject,
     create_ortho_cam.COATOOLS2_OT_CreateOrtpographicCamera,
     create_ortho_cam.COATOOLS2_OT_AlignCamera,
     create_spritesheet_preview.COATOOLS2_OT_SelectFrameThumb,

--- a/coa_tools2/functions.py
+++ b/coa_tools2/functions.py
@@ -44,7 +44,8 @@ from . import constants as CONSTANTS
 
 
 def get_active_tool(mode):  # "EDIT_MESH", "EDIT_ARMATURE", "OBJECT"
-    return bpy.context.workspace.tools.from_space_view3d_mode(mode, create=False).idname
+    tool = bpy.context.workspace.tools.from_space_view3d_mode(mode, create=False)
+    return tool.idname if tool else ""
 
 
 def set_active_tool(self, context, tool_name):
@@ -1063,17 +1064,17 @@ def change_slot_mesh_data(
     if sync_active:
         for slot2 in obj.coa_tools2.slot:
             if slot != slot2 and slot2.active:
-                object.__setattr__(slot2, "_lock_active_update", True)
+                slot2["_lock_active_update"] = True
                 try:
                     slot2.active = False
                 finally:
-                    object.__setattr__(slot2, "_lock_active_update", False)
+                    slot2["_lock_active_update"] = False
             elif slot == slot2 and not slot2.active:
-                object.__setattr__(slot2, "_lock_active_update", True)
+                slot2["_lock_active_update"] = True
                 try:
                     slot2.active = True
                 finally:
-                    object.__setattr__(slot2, "_lock_active_update", False)
+                    slot2["_lock_active_update"] = False
 
     if "coa_base_sprite" in obj.modifiers:
         hide_base_sprite = bool(slot.mesh.coa_tools2.hide_base_sprite)

--- a/coa_tools2/operators/animation_handling.py
+++ b/coa_tools2/operators/animation_handling.py
@@ -848,3 +848,77 @@ class COATOOLS2_OT_RemoveTimelineEvent(bpy.types.Operator):
 
         anim.timeline_events.remove(index)
         return {"FINISHED"}
+
+
+class COATOOLS2_OT_RenameSpriteObject(bpy.types.Operator):
+    bl_idname = "coa_tools2.rename_sprite_object"
+    bl_label = "Rename Sprite Object"
+    bl_description = "Rename the Sprite Object and update all associated animation action names to match"
+    bl_options = {"REGISTER"}
+
+    new_name: StringProperty(
+        name="Name",
+        description="New name for the Sprite Object",
+    )
+
+    @classmethod
+    def poll(cls, context):
+        sprite_object = get_sprite_object(context.active_object)
+        return sprite_object is not None
+
+    def invoke(self, context, event):
+        sprite_object = get_sprite_object(context.active_object)
+        self.new_name = sprite_object.name
+        wm = context.window_manager
+        return wm.invoke_props_dialog(self)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(self, "new_name")
+
+    def execute(self, context):
+        sprite_object = get_sprite_object(context.active_object)
+        if sprite_object is None:
+            self.report({"WARNING"}, "No Sprite Object found")
+            return {"CANCELLED"}
+
+        old_name = sprite_object.name
+        new_name = self.new_name.strip()
+
+        if new_name == "":
+            self.report({"WARNING"}, "Name cannot be empty")
+            return {"CANCELLED"}
+
+        if old_name == new_name:
+            return {"CANCELLED"}
+
+        # Collect objects that could have actions referencing their names.
+        # Action naming convention: {anim_collection.name}_{object_name}
+        children = get_children(context, sprite_object, ob_list=[])
+        anim_objects = []
+        if sprite_object.type == "ARMATURE":
+            anim_objects.append(sprite_object)
+        for child in children:
+            anim_objects.append(child)
+
+        # Rename actions for each animation collection
+        for item in sprite_object.coa_tools2.anim_collections:
+            for obj in anim_objects:
+                if obj.name == old_name:
+                    old_action_name = item.name + "_" + old_name
+                    new_action_name = item.name + "_" + new_name
+                    if old_action_name in bpy.data.actions and new_action_name not in bpy.data.actions:
+                        bpy.data.actions[old_action_name].name = new_action_name
+
+        # Rename objects that match the old name (sprite_object, and any children)
+        sprite_object.name = new_name
+        renamed_name = sprite_object.name  # Blender may have adjusted the name
+        for child in children:
+            if child.name == old_name:
+                child.name = renamed_name
+
+        self.report(
+            {"INFO"},
+            "Sprite Object renamed to '" + sprite_object.name + "' with animations updated",
+        )
+        return {"FINISHED"}

--- a/coa_tools2/operators/edit_armature.py
+++ b/coa_tools2/operators/edit_armature.py
@@ -586,21 +586,23 @@ class COATOOLS2_OT_QuickArmature(bpy.types.Operator):
 
         bpy.context.window.cursor_set("CROSSHAIR")
 
-        if context.active_object.type == "ARMATURE":
+        armature_obj = self.armature
+        if armature_obj and armature_obj.type == "ARMATURE":
+            context.view_layer.objects.active = armature_obj
             bpy.ops.object.mode_set(mode="POSE")
 
             if functions.b_version_smaller_than((4, 0, 0)):
-                for pose_bone in context.active_object.pose.bones:
+                for pose_bone in armature_obj.pose.bones:
                     if (
-                        "default_bones" in context.active_object.pose.bone_groups
+                        "default_bones" in armature_obj.pose.bone_groups
                         and pose_bone.bone_group == None
                     ):
-                        pose_bone.bone_group = context.active_object.pose.bone_groups[
+                        pose_bone.bone_group = armature_obj.pose.bone_groups[
                             "default_bones"
                         ]
             else:
-                for bone in context.active_object.data.bones:
-                    armature: bpy.types.Armature = context.active_object.data
+                for bone in armature_obj.data.bones:
+                    armature: bpy.types.Armature = armature_obj.data
                     if (
                         "default_bones" in [c.name for c in armature.collections]
                         and bone.collections == None

--- a/coa_tools2/operators/export_json.py
+++ b/coa_tools2/operators/export_json.py
@@ -283,7 +283,7 @@ class COATOOLS2_OT_ExportToJson(bpy.types.Operator, bpy_extras.io_utils.ExportHe
         else:
             local_mat = self.get_bone_transformation(bone)
         bone_scale = local_mat.decompose()[2]
-        bone_scale_2d = [bone_scale[1], bone_scale[1]]
+        bone_scale_2d = [bone_scale[0], bone_scale[1]]
         return bone_scale_2d
 
     def get_relative_bone_pos(self, bone, type):
@@ -332,7 +332,7 @@ class COATOOLS2_OT_ExportToJson(bpy.types.Operator, bpy_extras.io_utils.ExportHe
         bone_euler_rot = local_mat.decompose()[1].to_euler()
 
         degrees = round(math.degrees(bone_euler_rot.y), 2)
-        return -math.radians(degrees)
+        return math.radians(degrees)
 
     def get_relative_mesh_pos(self, parent, obj):
         if isinstance(parent, bpy.types.Bone):
@@ -406,15 +406,73 @@ class COATOOLS2_OT_ExportToJson(bpy.types.Operator, bpy_extras.io_utils.ExportHe
 
     def sprite_to_dict(self, sprite, bone=None):
         dict_sprites = OrderedDict()
+        obj = bpy.data.objects[sprite]
+
+        # Handle Slot objects - export all slot entries as children
+        if obj.coa_tools2.type == "SLOT" and len(obj.coa_tools2.slot) > 0:
+            dict_sprites["name"] = sprite
+            dict_sprites["type"] = "SLOT"
+            dict_sprites["node_path"] = str(self.get_node_path(obj, []))
+            # Slot container uses identity transform; children carry full transforms
+            dict_sprites["position"] = [0.0, 0.0]
+            dict_sprites["rotation"] = 0.0
+            dict_sprites["scale"] = [1.0, 1.0]
+            dict_sprites["opacity"] = 1.0
+            dict_sprites["z"] = 0
+            dict_sprites["children"] = []
+
+            original_mesh = obj.data
+            original_slot_index = obj.coa_tools2.slot_index
+            try:
+                for slot_entry in obj.coa_tools2.slot:
+                    if slot_entry.mesh is None:
+                        continue
+                    # Swap to this slot entry's mesh so helpers read correct data
+                    obj.data = slot_entry.mesh
+                    obj.coa_tools2.slot_index = slot_entry.index
+
+                    child_dict = OrderedDict()
+                    child_dict["name"] = "{}.{:03d}".format(sprite, slot_entry.index)
+                    child_dict["type"] = "SPRITE"
+                    child_dict["slot_index"] = slot_entry.index
+                    child_dict["node_path"] = str(self.get_node_path(obj, []))
+                    child_dict["resource_path"] = self.get_sprite_path(sprite)
+                    child_dict["pivot_offset"] = self.get_sprite_offset(sprite)
+                    child_dict["position"] = self.get_relative_mesh_pos(
+                        bone, obj
+                    )
+                    child_dict["rotation"] = self.get_sprite_rotation(sprite)
+                    child_dict["scale"] = self.get_sprite_scale(sprite)
+                    child_dict["opacity"] = self.get_sprite_opacity(sprite)
+                    child_dict["z"] = self.get_z_value(sprite)
+                    child_dict["tiles_x"] = self.get_sprite_tilesize(sprite)[0]
+                    child_dict["tiles_y"] = self.get_sprite_tilesize(sprite)[1]
+                    child_dict["frame_index"] = slot_entry.index
+                    child_dict["children"] = []
+
+                    dict_sprites["children"].append(child_dict)
+            finally:
+                obj.data = original_mesh
+                obj.coa_tools2.slot_index = original_slot_index
+
+            # Also process actual Blender children of the slot object
+            for child in bpy.data.objects[sprite].children:
+                if child.type == "MESH":
+                    dict_sprites["children"].append(
+                        self.sprite_to_dict(child.name, obj)
+                    )
+
+            return dict_sprites
+
         dict_sprites["name"] = sprite
         dict_sprites["type"] = "SPRITE"
         dict_sprites["node_path"] = str(
-            self.get_node_path(bpy.data.objects[sprite], [])
+            self.get_node_path(obj, [])
         )  # ,suffix=sprite))
         dict_sprites["resource_path"] = self.get_sprite_path(sprite)
         dict_sprites["pivot_offset"] = self.get_sprite_offset(sprite)
         dict_sprites["position"] = self.get_relative_mesh_pos(
-            bone, bpy.data.objects[sprite]
+            bone, obj
         )
         dict_sprites["rotation"] = self.get_sprite_rotation(sprite)
         dict_sprites["scale"] = self.get_sprite_scale(sprite)
@@ -428,7 +486,7 @@ class COATOOLS2_OT_ExportToJson(bpy.types.Operator, bpy_extras.io_utils.ExportHe
         for child in bpy.data.objects[sprite].children:
             if child.type == "MESH":
                 dict_sprites["children"].append(
-                    self.sprite_to_dict(child.name, bpy.data.objects[sprite])
+                    self.sprite_to_dict(child.name, obj)
                 )
 
         return dict_sprites
@@ -438,7 +496,7 @@ class COATOOLS2_OT_ExportToJson(bpy.types.Operator, bpy_extras.io_utils.ExportHe
         dict_bone["name"] = bone.name
         dict_bone["type"] = "BONE"
         dict_bone["node_path"] = str(self.get_node_path(bone, []))  # ,suffix=""))
-        dict_bone["draw_bone"] = self.armature.data.bones[bone.name].coa_draw_bone
+        dict_bone["draw_bone"] = self.armature.data.bones[bone.name].coa_tools2.draw_bone
         dict_bone["bone_connected"] = bone.use_connect
         dict_bone["position"] = self.get_relative_bone_pos(bone, "HEAD")
         dict_bone["position_tip"] = self.get_relative_bone_pos(bone, "TAIL")
@@ -706,6 +764,20 @@ class COATOOLS2_OT_ExportToJson(bpy.types.Operator, bpy_extras.io_utils.ExportHe
                             "animation_data": child.animation_data,
                         },
                     ]
+                if child.coa_tools2.type == "SLOT" and (
+                    self.has_animation_data(
+                        child.animation_data, "coa_tools2.slot_index"
+                    )
+                    or restpose
+                ):
+                    channels[self.get_node_path(child, []) + ":slot"] = [
+                        OrderedDict(),
+                        {
+                            "node_name": child.name,
+                            "time_idx_hist": "0.0",
+                            "animation_data": child.animation_data,
+                        },
+                    ]
                 if (
                     self.has_animation_data(
                         child.animation_data, "coa_tools2.modulate_color"
@@ -824,6 +896,13 @@ class COATOOLS2_OT_ExportToJson(bpy.types.Operator, bpy_extras.io_utils.ExportHe
                             track,
                             "modulate",
                             self.get_modulate_color(sprite),
+                            channels,
+                            key,
+                        )
+                        self.keyframe_to_dict(
+                            track,
+                            "slot",
+                            int(bpy.data.objects[sprite].coa_tools2.slot_index),
                             channels,
                             key,
                         )

--- a/coa_tools2/operators/exporter/export_dragonbones.py
+++ b/coa_tools2/operators/exporter/export_dragonbones.py
@@ -363,6 +363,11 @@ def get_bone_with_most_influence(self, sprite):
             if total_weight > max_weight:
                 max_weight = float(total_weight)
                 bone = self.armature.data.bones[v_group.name]
+
+    ### fallback: check if sprite is directly parented to a bone (parent_bone)
+    if bone is None and sprite.parent_bone in self.armature.data.bones:
+        bone = self.armature.data.bones[sprite.parent_bone]
+
     return bone
 
 
@@ -373,8 +378,21 @@ def get_slot_data(self, sprites):
         if sprite.type == "MESH":
             slot = OrderedDict()
             slot["name"] = sprite.name
-            if len(sprite.data.vertices) != 4:
-                slot["parent"] = self.sprite_object.name  # sprite.parent.name
+            ### Count effective vertices excluding coa_base_sprite.
+            ### Image sprites (4-vertex after base removal) need bone parent for correct animation.
+            n_verts = len(sprite.data.vertices)
+            if "coa_base_sprite" in sprite.vertex_groups:
+                base_vg_idx = sprite.vertex_groups["coa_base_sprite"].index
+                base_count = 0
+                for vert in sprite.data.vertices:
+                    for g in vert.groups:
+                        if g.group == base_vg_idx:
+                            base_count += 1
+                            break
+                n_verts -= base_count
+
+            if n_verts != 4:
+                slot["parent"] = self.sprite_object.name
             else:
                 bone_parent = get_bone_with_most_influence(self, sprite)
                 if bone_parent != None:
@@ -484,10 +502,11 @@ def delete_non_deform_bones(self, armature, sprites):
         has_children = len(bone.children) > 0
 
         if (
-            (not is_deform_bone and is_driver)
-            or (not is_deform_bone and is_const_target)
-            or (not is_deform_bone and not has_children)
-            or (not is_deform_bone and not bone.use_deform)
+            not is_deform_bone
+            and not is_driver
+            and not is_const_target
+            and not has_children
+            and not bone.use_deform
         ):
             armature.data.edit_bones.remove(armature.data.edit_bones[bone.name])
 
@@ -593,6 +612,14 @@ def get_skin_slot(self, sprite, armature, scale, slot_data=None):
         sprite_data = slot_data.copy()
     sprite = sprite.copy()
     sprite.data = sprite_data
+
+    ### Prevent depsgraph_update_post handler (update_properties) from resetting
+    ### mesh data on SLOT-type duplicates (it would set obj.data = slot[slot_index].mesh,
+    ### discarding the per-slot mesh we assigned above).
+    original_coa_type = sprite.coa_tools2.type
+    if original_coa_type == "SLOT":
+        sprite.coa_tools2.type = "MESH"
+
     context.collection.objects.link(sprite)
     context.view_layer.objects.active = sprite
 
@@ -642,11 +669,17 @@ def get_skin_slot(self, sprite, armature, scale, slot_data=None):
             display_data["width"] = int(img.size[0])
             display_data["height"] = int(img.size[1])
         elif self.scene.coa_tools2.export_image_mode == "ATLAS":
-            display_data["width"] = atlas_data[sprite_data_name]["width"]
-            display_data["height"] = atlas_data[sprite_data_name]["height"]
+            if sprite_data_name not in atlas_data:
+                print(f"COA DEBUG: '{sprite_data_name}' not in atlas_data. Keys: {list(atlas_data.keys())}")
+                # Fallback to image size if atlas data is missing
+                display_data["width"] = int(img.size[0]) if img is not None else 0
+                display_data["height"] = int(img.size[1]) if img is not None else 0
+            else:
+                display_data["width"] = atlas_data[sprite_data_name]["width"]
+                display_data["height"] = atlas_data[sprite_data_name]["height"]
 
         verts = get_mixed_vertex_data(sprite)
-        vert_coords_default[sprite_name] = verts
+        vert_coords_default[sprite_data_name] = verts
         display_data["vertices"] = convert_vertex_data_to_pixel_space(verts)
 
         bm = bmesh.from_edit_mesh(sprite.data)
@@ -710,7 +743,7 @@ def get_skin_slot(self, sprite, armature, scale, slot_data=None):
             if angle != 0:
                 display_data["transform"]["skX"] = -round(angle, 2)
                 display_data["transform"]["skY"] = -round(angle, 2)
-            if atlas_data[sprite_data_name]["output_scale"] != 1.0:
+            if sprite_data_name in atlas_data and atlas_data[sprite_data_name]["output_scale"] != 1.0:
                 display_data["transform"]["scX"] = round(
                     1.0 / atlas_data[sprite_data_name]["output_scale"], 2
                 )
@@ -741,10 +774,13 @@ def get_skin_data(self, sprites, armature, scale):
 
         if sprite.type == "MESH":
             if sprite.coa_tools2.type == "MESH":
+                print(f"COA DEBUG: skin MESH sprite='{sprite.name}' data.name='{sprite.data.name}'")
                 data2 = get_skin_slot(self, sprite, armature, scale)
                 slot_data["display"].append(data2)
             elif sprite.coa_tools2.type == "SLOT":
                 for slot in sprite.coa_tools2.slot:
+                    mesh_name = slot.mesh.name if slot.mesh else "None"
+                    print(f"COA DEBUG: skin SLOT sprite='{sprite.name}' slot.mesh.name='{mesh_name}'")
                     data2 = get_skin_slot(
                         self, sprite, armature, scale, slot_data=slot.mesh
                     )
@@ -874,15 +910,27 @@ def get_bone_data(self, armature, sprite_object, scale):
             data["transform"]["scX"] = round(sca[0], 2)
             data["transform"]["scY"] = round(sca[1], 2)
 
-        if int(bone.use_inherit_rotation) != 1 or bone_uses_constraints[pbone.name]:
+        # Bone.inherit_rotation/inherit_scale API changed in Blender 4.3:
+        # use_inherit_rotation (bool) → inherit_rotation (enum)
+        # use_inherit_scale (bool)    → inherit_scale (enum)
+        try:
+            inherit_rotation = int(bone.use_inherit_rotation)
+        except AttributeError:
+            inherit_rotation = 0 if bone.inherit_rotation in (0, 'FULL') else 1
+        try:
+            inherit_scale = int(bone.use_inherit_scale)
+        except AttributeError:
+            inherit_scale = 0 if bone.inherit_scale in (0, 'FULL') else 1
+
+        if inherit_rotation != 1 or bone_uses_constraints[pbone.name]:
             data["inheritRotation"] = (
-                int(bone.use_inherit_rotation)
+                inherit_rotation
                 if not bone_uses_constraints[pbone.name]
                 else 0
             )
-        if int(bone.use_inherit_scale) != 1 or bone_uses_constraints[pbone.name]:
+        if inherit_scale != 1 or bone_uses_constraints[pbone.name]:
             data["inheritScale"] = (
-                int(bone.use_inherit_scale)
+                inherit_scale
                 if not bone_uses_constraints[pbone.name]
                 else 0
             )
@@ -963,7 +1011,7 @@ def bone_key_on_frame(
                 for strip in layer.strips:
                     for slot in action.slots:
                         for fcurve in strip.channelbag(slot).fcurves:
-                            if slot.name in fcurve.data_path and (
+                            if (getattr(slot, 'name', str(slot)) in fcurve.data_path) and (
                                 type in fcurve.data_path or type == ".any"
                             ):
                                 for keyframe in fcurve.keyframe_points:
@@ -1146,7 +1194,6 @@ def get_animation_data(self, sprite_object, armature, armature_orig):
             SHAPEKEY_ANIMATION = {}
             for i in range(anim.frame_end + 1):
                 frame = anim.frame_end - i
-                slot_data = None
                 for slot in self.sprites:
                     if slot.type == "MESH":
                         slot_data = []
@@ -1155,20 +1202,20 @@ def get_animation_data(self, sprite_object, armature, armature_orig):
                         elif slot.coa_tools2.type == "SLOT":
                             for slot2 in slot.coa_tools2.slot:
                                 slot_data.append(tmp_slots_data[slot2.mesh.name])
-                if slot_data != None:
-                    for item in slot_data:
-                        data = item["data"]
-                        data_name = item["name"]
 
-                        key_blocks = []
-                        if data.shape_keys != None:
-                            for key in data.shape_keys.key_blocks:
-                                key_blocks.append(key.name)
-                        if property_key_on_frame(
-                            data, key_blocks, frame, type="SHAPEKEY"
-                        ):
-                            SHAPEKEY_ANIMATION[slot.name] = True
-                            break
+                        for item in slot_data:
+                            data = item["data"]
+                            data_name = item["name"]
+
+                            key_blocks = []
+                            if data.shape_keys != None:
+                                for key in data.shape_keys.key_blocks:
+                                    key_blocks.append(key.name)
+                            if property_key_on_frame(
+                                data, key_blocks, frame, type="SHAPEKEY"
+                            ):
+                                SHAPEKEY_ANIMATION[slot.name] = True
+                                break
 
             ### append all bones to list
             bone_keyframe_duration = {}
@@ -1544,7 +1591,7 @@ def get_animation_data(self, sprite_object, armature, armature_orig):
                                     data, key_blocks, frame, type="SHAPEKEY"
                                 ) or (
                                     frame in [0, anim.frame_end]
-                                    and data_name in SHAPEKEY_ANIMATION
+                                    and slot.name in SHAPEKEY_ANIMATION
                                 ):  # or bake_anim:
                                     ffd_data = {}
                                     ffd_data["duration"] = ffd_keyframe_duration[
@@ -1565,7 +1612,7 @@ def get_animation_data(self, sprite_object, armature, armature_orig):
                                     for i, co in enumerate(verts):
                                         verts_relative.append(
                                             Vector(co)
-                                            - Vector(vert_coords_default[slot.name][i])
+                                            - Vector(vert_coords_default[data_name][i])
                                         )
 
                                     ffd_data["vertices"] = (
@@ -1700,6 +1747,9 @@ class COATOOLS2_OT_DragonBonesExport(bpy.types.Operator):
 
         self.get_init_state(context)
         self.scene = context.scene
+
+        ### Switch to NO ACTION to ensure clean initial state for export data
+        self.sprite_object.coa_tools2.anim_collections_index = 0
 
         ### set animation mode to action
         coa_nla_mode = str(self.scene.coa_tools2.nla_mode)
@@ -1909,13 +1959,29 @@ def generate_texture_atlas(
                     slots.append({"sprite": sprite, "slot": slot.mesh})
 
     ### loop over all slots and create an object with slot assigned
+    ### Vertex groups are NOT created here — deferred to after the loop to avoid
+    ### the depsgraph_update_post handler (update_properties) from interfering.
+    ### That handler checks for SLOT-type objects and calls change_slot_mesh_data,
+    ### which can reset the object's mesh data and undo vertex group operations.
+    pending_vg = []
     for slot in slots:
+        slot_name = slot["slot"].name if slot["slot"] else "None"
+        print(f"COA DEBUG: atlas slot sprite='{slot['sprite'].name}' slot.name='{slot_name}'")
         dupli_sprite = slot["sprite"].copy()
         dupli_sprite.data = slot["slot"].copy()
         context.collection.objects.link(dupli_sprite)
         dupli_sprite.hide_set(False)
         dupli_sprite.select_set(True)
         context.view_layer.objects.active = dupli_sprite
+        ### ensure single-user data to prevent "modifier cannot be applied to multi-user data"
+        if dupli_sprite.data.users > 1:
+            dupli_sprite.data = dupli_sprite.data.copy()
+
+        ### Temporarily set coa_tools2.type to "MESH" to prevent the depsgraph_update_post
+        ### handler from interfering with SLOT-type duplicates during modifier baking.
+        original_coa_type = dupli_sprite.coa_tools2.type
+        if original_coa_type == "SLOT":
+            dupli_sprite.coa_tools2.type = "MESH"
 
         ### delete shapekeys
         if dupli_sprite.data.shape_keys != None:
@@ -1924,46 +1990,56 @@ def generate_texture_atlas(
                 shapekeys = dupli_sprite.data.shape_keys.key_blocks
                 dupli_sprite.shape_key_remove(shapekeys[len(shapekeys) - 1])
         ### apply/delete modifieres
+        ### Blender 2.80+: bake modifiers via depsgraph evaluation to avoid
+        ### "modifier cannot be applied to multi-user data" error in Blender 5.x.
+        ### The operator's multi-user check can fail even when data.users == 1 due to
+        ### context override issues in newer Blender versions.
+        mask_modifier = None
         for modifier in dupli_sprite.modifiers:
             if modifier.name == "coa_base_sprite" and modifier.type == "MASK":
                 if len(dupli_sprite.data.vertices) > 4:
                     modifier.invert_vertex_group = True
-                    with bpy.context.temp_override(
-                        object=dupli_sprite, active_object=dupli_sprite
-                    ):
-                        if b_version_smaller_than((2, 90, 0)):
-                            bpy.ops.object.modifier_apply(
-                                apply_as="DATA", modifier=modifier.name
-                            )
-                        else:
-                            bpy.ops.object.modifier_apply(modifier=modifier.name)
+                    mask_modifier = modifier
+                    break  # Found the MASK modifier with >4 vertices
+
+        if mask_modifier is not None:
+            if b_version_smaller_than((2, 80, 0)):
+                # Blender < 2.80: use operator-based approach
+                with bpy.context.temp_override(
+                    object=dupli_sprite, active_object=dupli_sprite
+                ):
+                    bpy.ops.object.modifier_apply(
+                        apply_as="DATA", modifier=mask_modifier.name
+                    )
+            else:
+                # Blender 2.80+: use depsgraph evaluation to bake modifiers,
+                # avoiding operator context dependency issues.
+                # Copy evaluated mesh data to preserve all layers (UVs, etc.)
+                depsgraph = context.evaluated_depsgraph_get()
+                obj_eval = dupli_sprite.evaluated_get(depsgraph)
+                dupli_sprite.data = obj_eval.data.copy()
         for modifier in dupli_sprite.modifiers:
             dupli_sprite.modifiers.remove(modifier)
 
-        ### delete vertex_groups
-        for group in dupli_sprite.vertex_groups:
+        ### Keep type as "MESH" to protect against handler interference later.
+        ### The vertex groups will be set after the loop, so we don't need to restore SLOT here.
+        pending_vg.append((dupli_sprite, slot["slot"].name))
+
+    ### NOW create vertex groups — after ALL depsgraph evaluations have completed,
+    ### so the depsgraph_update_post handler won't interfere.
+    for dupli_sprite, vg_name in pending_vg:
+        ### delete old vertex_groups (use list() to avoid skipping items)
+        groups_to_delete = list(dupli_sprite.vertex_groups)
+        for group in groups_to_delete:
             dupli_sprite.vertex_groups.remove(group)
 
         ### assign mesh as vertex group
-        dupli_sprite.vertex_groups.new(name=slot["slot"].name)
-        bpy.ops.object.mode_set(mode="EDIT")
-        bpy.ops.mesh.reveal()
-        bpy.ops.mesh.select_all(action="SELECT")
-        for area in context.screen.areas:
-            if area.type == "VIEW_3D":
-                for region in area.regions:
-                    if region.type == "WINDOW":
-                        with bpy.context.temp_override(
-                            area=area,
-                            edict_object=dupli_sprite,
-                            active_object=dupli_sprite,
-                            object=dupli_sprite,
-                            region=region,
-                        ):
-                            bpy.ops.object.vertex_group_assign()
-                        break
-
+        vg = dupli_sprite.vertex_groups.new(name=vg_name)
+        print(f"COA DEBUG: created vg '{vg_name}' for dupli '{dupli_sprite.name}'")
+        # Use direct API to assign all vertices (avoids bpy.ops.object.vertex_group_assign
+        # poll issues in Blender 5.0 where the active vertex group may appear locked)
         bpy.ops.object.mode_set(mode="OBJECT")
+        vg.add([v.index for v in dupli_sprite.data.vertices], 1.0, 'REPLACE')
 
     img_atlas, tex_atlas_obj, atlas = TextureAtlasGenerator.generate_uv_layout(
         name="COA_UV_ATLAS",
@@ -2039,6 +2115,13 @@ def generate_texture_atlas(
             "output_scale": atlas.output_scale,
         }
 
+    print(f"COA DEBUG: atlas_data keys after loop: {list(atlas_data.keys())}")
+    ### Debug: check vertex groups on merged object after join
+    print(f"COA DEBUG: post-join merged object:")
+    for obj in context.selected_objects:
+        if obj.type == "MESH":
+            vg_names = [vg.name for vg in obj.vertex_groups]
+            print(f"  '{obj.name}' vgs={vg_names} data.name='{obj.data.name}'")
     bpy.ops.object.mode_set(mode="OBJECT")
     ### collect sprite atlas data
     texture_atlas = {}

--- a/coa_tools2/operators/exporter/texture_atlas_generator.py
+++ b/coa_tools2/operators/exporter/texture_atlas_generator.py
@@ -199,6 +199,12 @@ class TextureAtlasGenerator:
                                         atlas_data.width *= 2
                             elif atlas_data.height > atlas_data.width and atlas_data.width < atlas_data.max_width:
                                 atlas_data.width *= 2
+                            elif atlas_data.width > atlas_data.height and atlas_data.height < atlas_data.max_height:
+                                atlas_data.height *= 2
+                            elif atlas_data.width < atlas_data.max_width and atlas_data.height >= atlas_data.max_height:
+                                atlas_data.width *= 2
+                            elif atlas_data.height < atlas_data.max_height and atlas_data.width >= atlas_data.max_width:
+                                atlas_data.height *= 2
 
                             if atlas_data.width >= atlas_data.max_width and atlas_data.height >= atlas_data.max_height:
                                 decrease_scale = True

--- a/coa_tools2/operators/import_sprites.py
+++ b/coa_tools2/operators/import_sprites.py
@@ -267,6 +267,12 @@ class COATOOLS2_OT_LoadJsonData(bpy.types.Operator):
             ("ADD", "Add as New", "Add as New", "FORWARD", 1),
         )
     )
+    update_sprite_name: BoolProperty(
+        name="Update Sprite Name",
+        description="Update the Sprite Object name from JSON data. "
+        "Disable this to keep the current object name and preserve animation data.",
+        default=True,
+    )
 
     @classmethod
     def poll(cls, context):
@@ -280,6 +286,8 @@ class COATOOLS2_OT_LoadJsonData(bpy.types.Operator):
 
         row = layout.row()
         row.prop(self, "mode", expand=True)
+        row = layout.row()
+        row.prop(self, "update_sprite_name")
         col = layout.column()
         box = col.box()
         box.prop(self, "active_all", text="Import All")
@@ -315,7 +323,7 @@ class COATOOLS2_OT_LoadJsonData(bpy.types.Operator):
 
         sprite_object = functions.get_sprite_object(context.active_object)
 
-        if "name" in sprite_data:
+        if "name" in sprite_data and self.update_sprite_name:
             sprite_object.name = sprite_data["name"]
 
         if "nodes" in sprite_data:
@@ -669,6 +677,7 @@ class COATOOLS2_OT_ReImportSprite(bpy.types.Operator, ImportHelper):
                     break
         if not sprite_found:
             img = bpy.data.images.load(self.filepath)
+            prev_img_size = img.size[:]
 
         scale = functions.get_addon_prefs(context).sprite_import_export_scale
         if self.name in bpy.data.objects:

--- a/coa_tools2/operators/slot_handling.py
+++ b/coa_tools2/operators/slot_handling.py
@@ -195,11 +195,11 @@ class COATOOLS2_OT_CreateSlotObject(bpy.types.Operator):
                             # item.name = slot.name
                             item.mesh = slot.mesh
                     if item != None:
-                        object.__setattr__(item, "_lock_active_update", True)
+                        item["_lock_active_update"] = True
                         try:
                             item.active = False
                         finally:
-                            object.__setattr__(item, "_lock_active_update", False)
+                            item["_lock_active_update"] = False
         obj.coa_tools2.slot[0].active = True
         ### delete original sprite
         for sprite in objs:

--- a/coa_tools2/properties.py
+++ b/coa_tools2/properties.py
@@ -342,10 +342,10 @@ class SlotData(bpy.types.PropertyGroup):
     def change_slot_mesh(self, context):
         obj = self.id_data
 
-        if getattr(self, "_lock_active_update", False):
+        if self.get("_lock_active_update", False):
             return
 
-        object.__setattr__(self, "_lock_active_update", True)
+        self["_lock_active_update"] = True
         try:
             if not self.active:
                 self.active = True
@@ -354,13 +354,13 @@ class SlotData(bpy.types.PropertyGroup):
             functions.hide_base_sprite(obj)
             for slot in obj.coa_tools2.slot:
                 if slot != self and slot.active:
-                    object.__setattr__(slot, "_lock_active_update", True)
+                    slot["_lock_active_update"] = True
                     try:
                         slot.active = False
                     finally:
-                        object.__setattr__(slot, "_lock_active_update", False)
+                        slot["_lock_active_update"] = False
         finally:
-            object.__setattr__(self, "_lock_active_update", False)
+            self["_lock_active_update"] = False
 
     mesh: bpy.props.PointerProperty(type=bpy.types.Mesh)
     offset: FloatVectorProperty()

--- a/coa_tools2/ui.py
+++ b/coa_tools2/ui.py
@@ -237,7 +237,14 @@ class COATOOLS2_PT_ObjectProperties(bpy.types.Panel):
             elif obj.type == "LAMP":
                 icon = "LAMP"
 
-            col.prop(obj, "name", text="", icon=icon)
+            name_row = col.row(align=True)
+            name_row.prop(obj, "name", text="", icon=icon)
+            if obj == sprite_object:
+                name_row.operator(
+                    "coa_tools2.rename_sprite_object",
+                    text="",
+                    icon="GREASEPENCIL",
+                )
             if obj.type == "MESH" and obj.coa_tools2.type == "SLOT":
                 index = functions.get_clamped_slot_index(obj)
                 if index is not None:


### PR DESCRIPTION
- Fix Blender 4.3+ bone inherit property compatibility
- Fix export failure when not in NO ACTION state
- Fix atlas generation hang on non-square textures
- Fix bone scale/rotation export calculation errors
- Fix Blender 5.x modifier baking compatibility
- Fix SLOT duplicate mesh data being reset
- Fix SHAPEKEY animation detection errors
- Fix slot object compatibility in keyframe detection
- Add option to preserve Sprite Object name on re-import
- Fix image size loss during re-import
- Refactor PropertyGroup attribute access
- Add Sprite Object rename button to UI